### PR TITLE
fix(fetch): surface semaphore-closed as typed error instead of panic (P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to webclaw are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.3.15] — 2026-04-16
+
+### Fixed
+- **Batch/crawl no longer panics on semaphore close (P1).** Three `permit.acquire().await.expect("semaphore closed")` call sites in `webclaw-fetch` (`client::fetch_batch`, `client::fetch_and_extract_batch_with_options`, `crawler` inner loop) now surface a typed `FetchError::Build("semaphore closed before acquire")` or a failed `PageResult` instead of panicking the spawned task. Under normal operation nothing changes; under shutdown-race or adversarial runtime state, the caller sees one failed entry in the batch instead of losing the task silently to the runtime's panic handler. Surfaced by the 2026-04-16 workspace audit.
+
+---
+
 ## [0.3.14] — 2026-04-16
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-cli"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "clap",
  "dotenvy",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-core"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "ego-tree",
  "once_cell",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-fetch"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "bytes",
  "calamine",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-llm"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-mcp"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "dirs",
  "dotenvy",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-pdf"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "pdf-extract",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.3.14"
+version = "0.3.15"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/0xMassi/webclaw"

--- a/crates/webclaw-fetch/src/client.rs
+++ b/crates/webclaw-fetch/src/client.rs
@@ -390,8 +390,14 @@ impl FetchClient {
             let url = url.to_string();
 
             handles.push(tokio::spawn(async move {
-                let _permit = permit.acquire().await.expect("semaphore closed");
-                let result = client.fetch(&url).await;
+                // Don't panic if the semaphore has been closed under us
+                // (adversarial runtime state or shutdown race). Surface a
+                // typed error instead so the caller sees one failed URL in
+                // the batch instead of a silently-dropped task.
+                let result = match permit.acquire().await {
+                    Ok(_permit) => client.fetch(&url).await,
+                    Err(_) => Err(FetchError::Build("semaphore closed before acquire".into())),
+                };
                 (idx, BatchResult { url, result })
             }));
         }
@@ -430,8 +436,10 @@ impl FetchClient {
             let opts = options.clone();
 
             handles.push(tokio::spawn(async move {
-                let _permit = permit.acquire().await.expect("semaphore closed");
-                let result = client.fetch_and_extract_with_options(&url, &opts).await;
+                let result = match permit.acquire().await {
+                    Ok(_permit) => client.fetch_and_extract_with_options(&url, &opts).await,
+                    Err(_) => Err(FetchError::Build("semaphore closed before acquire".into())),
+                };
                 (idx, BatchExtractResult { url, result })
             }));
         }

--- a/crates/webclaw-fetch/src/crawler.rs
+++ b/crates/webclaw-fetch/src/crawler.rs
@@ -294,12 +294,27 @@ impl Crawler {
                 let delay = self.config.delay;
 
                 handles.push(tokio::spawn(async move {
-                    // Acquire permit -- blocks if concurrency limit reached
-                    let _permit = permit.acquire().await.expect("semaphore closed");
-                    tokio::time::sleep(delay).await;
-
+                    // Acquire permit -- blocks if concurrency limit reached.
+                    // Surface semaphore-closed as a failed PageResult rather
+                    // than panicking the spawned task and silently dropping
+                    // it from the batch.
                     let page_start = Instant::now();
-                    let result = client.fetch_and_extract(&url).await;
+                    let result = match permit.acquire().await {
+                        Ok(_permit) => {
+                            tokio::time::sleep(delay).await;
+                            client.fetch_and_extract(&url).await
+                        }
+                        Err(_) => {
+                            warn!(url = %url, depth, "semaphore closed before acquire");
+                            return PageResult {
+                                url,
+                                depth,
+                                extraction: None,
+                                error: Some("semaphore closed before acquire".into()),
+                                elapsed: page_start.elapsed(),
+                            };
+                        }
+                    };
                     let elapsed = page_start.elapsed();
 
                     match result {


### PR DESCRIPTION
## Summary

Replaces three `.expect(\"semaphore closed\")` panics in `webclaw-fetch` batch/crawl paths with a typed `FetchError::Build` or a failed `PageResult`. Happy-path is a no-op; under shutdown race / adversarial runtime state the caller now sees one failed entry in the batch instead of a silently-dropped task.

## Before
```rust
let _permit = permit.acquire().await.expect(\"semaphore closed\");
```

## After
```rust
let result = match permit.acquire().await {
    Ok(_permit) => client.fetch(&url).await,
    Err(_) => Err(FetchError::Build(\"semaphore closed before acquire\".into())),
};
```

## Changes
- `crates/webclaw-fetch/src/client.rs`: `fetch_batch` + `fetch_and_extract_batch_with_options`
- `crates/webclaw-fetch/src/crawler.rs`: inner per-URL task
- `Cargo.toml`: 0.3.14 → 0.3.15
- `CHANGELOG.md`: new 0.3.15 entry under Fixed

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo test -p webclaw-fetch` passes (1 test; the batch harness)
- [ ] Manual: run `webclaw https://example.com url2 url3 --concurrency 3` via the rebuilt CLI; should still succeed end-to-end

Per project memory: test CLI on both Mac (arm64) and VPS (amd64) before tagging 0.3.15.

## Refs
- Audit report: workspace `docs/AUDIT-2026-04-16.md`
- Call sites: `client.rs:393, 433`, `crawler.rs:298`

🤖 Generated with [Claude Code](https://claude.com/claude-code)