### PR TITLE
fix(fetch): guard challenge detection before utf8 decoding

### DIFF
--- a/crates/webclaw-fetch/src/client.rs
+++ b/crates/webclaw-fetch/src/client.rs
@@ -783,6 +783,10 @@ fn is_pdf_content_type(headers: &http::HeaderMap) -> bool {
 
 /// Detect if a response looks like a bot protection challenge page.
 fn is_challenge_response(response: &Response) -> bool {
+    let body_len = response.body().len();
+    if body_len > 15_000 || body_len == 0 {
+        return false;
+    }
     is_challenge_html(response.text().as_ref())
 }
 


### PR DESCRIPTION
### Motivation
- Prevent a DoS where `response.text()` (which uses `String::from_utf8_lossy`) decodes large or invalid-UTF-8 bodies and allocates heavily before the challenge-page size check, by short-circuiting on the raw byte length first.

### Description
- Add a pre-decode size guard in `is_challenge_response` that checks `response.body().len()` and returns early when the length is `0` or `> 15_000`, avoiding costly lossy UTF-8 conversion while preserving the existing `is_challenge_html` heuristic (`crates/webclaw-fetch/src/client.rs`).

### Testing
- Ran `cargo test -p webclaw-fetch --lib` and all tests passed (`220 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01de186f208330a6256247de60053e)