### PR TITLE
fix(ci): scope release workflow token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,15 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
+    permissions:
+      contents: read
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -106,9 +107,9 @@ jobs:
     name: Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -122,18 +123,23 @@ jobs:
           cat SHA256SUMS
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            artifacts/*.tar.gz
-            artifacts/*.zip
-            artifacts/SHA256SUMS
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          gh release create "$tag" \
+            artifacts/*.tar.gz \
+            artifacts/*.zip \
+            artifacts/SHA256SUMS \
+            --generate-notes
 
   docker:
     name: Docker
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -193,6 +199,8 @@ jobs:
     name: Update Homebrew
     needs: [release, docker]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Compute all checksums and update formula
         env:


### PR DESCRIPTION
### Motivation
- The release workflow previously granted workflow-wide `contents: write` and invoked multiple mutable third-party actions, exposing a write-capable `GITHUB_TOKEN` and a Homebrew tap secret to unpinned actions and increasing supply-chain risk.
- The change aims to apply least-privilege to CI tokens and avoid running third-party actions with broad write credentials so release artifacts and the Homebrew tap cannot be tampered with via a compromised action.

### Description
- Set workflow-level permissions to `contents: read` so the default token is read-only.
- Added job-level `permissions` so only the `release` job receives `contents: write`, `docker` is limited to `packages: write` and read for contents, and `build`/`homebrew` remain read-only.
- Removed `softprops/action-gh-release@v2` and replaced it with a `gh release create` `run` step that uses `GITHUB_TOKEN` from secrets to publish assets without invoking an external write-capable action, and removed the unnecessary `actions/checkout` from the `release` job.
- Preserved existing build, artifact upload/download, checksum generation, Docker image push, and Homebrew formula generation behavior while narrowing token exposure.

### Testing
- Verified the modified workflow file contents with `sed -n '1,220p' .github/workflows/release.yml` and confirmed the new `permissions` blocks were present (succeeded).
- Inspected the changes with `git diff -- .github/workflows/release.yml` to confirm the permission scoping and `gh`-based release step (succeeded).
- Displayed the final workflow with `nl -ba .github/workflows/release.yml` to validate job-level permission placements (succeeded).
- Created the PR metadata using `make_pr` to capture this change (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e2cce2948330b675624a5437849e)