### PR TITLE
docs: add community plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,19 @@ Please remove secrets, cookies, private tokens, and customer data from logs befo
 
 ---
 
+## Community Plugins
+
+Third-party plugins that integrate webclaw with AI agent platforms:
+
+| Plugin | Platform | What it does |
+|---|---|---|
+| [openclaw-webclaw](https://github.com/jal-co/openclaw-webclaw) | [OpenClaw](https://openclaw.ai) | Replaces the bundled Firecrawl plugin with native WebClaw v1 API — 9 tools: scrape, search, crawl, extract, summarize, diff, map, batch, brand |
+| [hermes-webclaw](https://github.com/jal-co/hermes-webclaw) | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Web search provider + 9 dedicated tools for the full v1 API surface. Install with `hermes plugins install jal-co/hermes-webclaw` |
+
+Built a webclaw integration? [Open a PR](https://github.com/0xMassi/webclaw/pulls) to add it here.
+
+---
+
 ## Contributors
 
 Thanks to everyone improving webclaw through issues, examples, docs, bug reports, and pull requests.

--- a/README.md
+++ b/README.md
@@ -383,8 +383,8 @@ Third-party plugins that integrate webclaw with AI agent platforms:
 
 | Plugin | Platform | What it does |
 |---|---|---|
-| [openclaw-webclaw](https://github.com/jal-co/openclaw-webclaw) | [OpenClaw](https://openclaw.ai) | Replaces the bundled Firecrawl plugin with native WebClaw v1 API — 9 tools: scrape, search, crawl, extract, summarize, diff, map, batch, brand |
-| [hermes-webclaw](https://github.com/jal-co/hermes-webclaw) | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Web search provider + 9 dedicated tools for the full v1 API surface. Install with `hermes plugins install jal-co/hermes-webclaw` |
+| [openclaw-webclaw](https://github.com/jal-co/openclaw-webclaw) | [OpenClaw](https://openclaw.ai) | Native webclaw v1 API plugin with 9 tools: scrape, search, crawl, extract, summarize, diff, map, batch, brand |
+| [hermes-webclaw](https://github.com/jal-co/hermes-webclaw) | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Web search provider and 9 dedicated tools for the full v1 API surface. Install with `hermes plugins install jal-co/hermes-webclaw` |
 
 Built a webclaw integration? [Open a PR](https://github.com/0xMassi/webclaw/pulls) to add it here.
 


### PR DESCRIPTION
## What

Adds a **Community Plugins** section to the README listing third-party integrations that bring WebClaw to AI agent platforms.

## Why

Users on OpenClaw and Hermes Agent can now discover native WebClaw plugins directly from the main repo README, rather than searching separately.

## Plugins added

| Plugin | Platform | Description |
|---|---|---|
| [openclaw-webclaw](https://github.com/jal-co/openclaw-webclaw) | OpenClaw | Replaces Firecrawl with native WebClaw v1 API — 9 tools |
| [hermes-webclaw](https://github.com/jal-co/hermes-webclaw) | Hermes Agent | Web search provider + 9 dedicated tools, installable via `hermes plugins install` |

Both plugins are open source (AGPL-3.0) and use the WebClaw v1 REST API.

## Placement

Added between the Contributing and Contributors sections, with an invite for others to PR their own integrations.