### PR TITLE
Strip more llm output noise: consent walls, bare integers, JSON-LD body duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to webclaw are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.6.0] — 2026-05-10
+
+### Fixed
+- Improved `--format llm` output quality on modern news and documentation pages. Framework hydration blobs and low-value page chrome structured-data records are now filtered out before they can flood the LLM context, while content-bearing Schema.org records are preserved. Thanks and congrats to Nenad Oric (`@devnen`) for the contribution in PR #37.
+- Fixed element-to-text spacing so adjacent inline nodes no longer smash words together, while punctuation stays attached on real pages such as docs, forums, and reference sites.
+- Removed common screen-reader-only link chrome such as "opens new tab" from LLM body text and link labels without stripping ordinary prose that happens to mention external links.
+
+---
+
 ## [0.5.9] — 2026-05-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-cli"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "clap",
  "dotenvy",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-core"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "ego-tree",
  "once_cell",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-fetch"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-llm"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-mcp"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "dirs",
  "dotenvy",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-pdf"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "pdf-extract",
  "thiserror",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-server"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.5.9"
+version = "0.6.0"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/0xMassi/webclaw"

--- a/crates/webclaw-cli/src/main.rs
+++ b/crates/webclaw-cli/src/main.rs
@@ -35,10 +35,38 @@ const ANTIBOT_TITLES: &[&str] = &[
     "ddos protection",
 ];
 
-/// Detect why a page returned empty content.
+/// URL host/path fragments that indicate a GDPR/cookie consent redirect.
+/// Yahoo, Google, and several EU news sites redirect to a `consent.*` host
+/// (or `/consent/` path) when the client is detected as being in the EU/EEA.
+/// The resulting page has near-zero usable content and a locale-specific
+/// title, so URL-shape detection is the most reliable signal.
+const CONSENT_URL_FRAGMENTS: &[&str] = &[
+    "://consent.",
+    "/consent?",
+    "/consent/",
+    "collectconsent",
+    "consentcheck",
+    "/cmp/",
+    "guce.advertising.com",
+];
+
+/// English consent-wall title prefixes. Many providers localise the page,
+/// so this is a best-effort secondary signal — primary detection is the URL.
+const CONSENT_TITLES: &[&str] = &[
+    "before you continue",
+    "your privacy choices",
+    "we value your privacy",
+    "we care about your privacy",
+    "cookie consent",
+    "consent required",
+];
+
+/// Detect why a page returned empty (or near-empty) content.
 enum EmptyReason {
     /// Anti-bot challenge page (Cloudflare, Akamai, etc.)
     Antibot,
+    /// GDPR/cookie consent redirect — content is gated behind a consent form
+    ConsentWall,
     /// JS-only SPA that returns an empty shell without a browser
     JsRequired,
     /// Page has content — not empty
@@ -46,6 +74,13 @@ enum EmptyReason {
 }
 
 fn detect_empty(result: &ExtractionResult) -> EmptyReason {
+    // Consent walls come back with a non-empty (but tiny) markdown body and a
+    // post-redirect URL pointing at a consent host. Check before the
+    // word-count short-circuit so the Yahoo / Google / EU case is caught.
+    if is_consent_wall(result) {
+        return EmptyReason::ConsentWall;
+    }
+
     // Has real content — nothing to warn about
     if result.metadata.word_count > 50 || !result.content.markdown.is_empty() {
         return EmptyReason::None;
@@ -67,12 +102,39 @@ fn detect_empty(result: &ExtractionResult) -> EmptyReason {
     EmptyReason::None
 }
 
+/// A consent wall is identified by either:
+/// 1. The final (post-redirect) URL pointing at a known consent host/path, OR
+/// 2. A consent-wall title prefix, AND the body being very short (<= 50 words)
+fn is_consent_wall(result: &ExtractionResult) -> bool {
+    if let Some(ref url) = result.metadata.url {
+        let lower = url.to_ascii_lowercase();
+        if CONSENT_URL_FRAGMENTS.iter().any(|f| lower.contains(f)) {
+            return true;
+        }
+    }
+    if result.metadata.word_count <= 50
+        && let Some(ref title) = result.metadata.title
+    {
+        let lower = title.to_lowercase();
+        if CONSENT_TITLES.iter().any(|t| lower.starts_with(t)) {
+            return true;
+        }
+    }
+    false
+}
+
 fn warn_empty(url: &str, reason: &EmptyReason) {
     match reason {
         EmptyReason::Antibot => eprintln!(
             "\x1b[33mwarning:\x1b[0m Anti-bot protection detected on {url}\n\
              This site requires CAPTCHA solving or browser rendering.\n\
              Use the webclaw Cloud API for automatic bypass: https://webclaw.io/pricing"
+        ),
+        EmptyReason::ConsentWall => eprintln!(
+            "\x1b[33mwarning:\x1b[0m GDPR/cookie consent wall detected on {url}\n\
+             The site redirected to a consent page and returned no usable content.\n\
+             Try a non-EU proxy via --proxy, or pass a pre-accepted consent cookie\n\
+             via --cookie / --cookie-file."
         ),
         EmptyReason::JsRequired => eprintln!(
             "\x1b[33mwarning:\x1b[0m No content extracted from {url}\n\
@@ -387,10 +449,15 @@ impl From<Browser> for BrowserProfile {
 }
 
 fn init_logging(verbose: bool) {
+    // html5ever / markup5ever / selectors emit WARN on every page with real-world
+    // HTML quirks (foster-parenting, malformed tables). They are not actionable
+    // and pollute stderr with dozens of lines per fetch. Silence by default; users
+    // who need them can override via WEBCLAW_LOG.
+    let default = "warn,html5ever=error,markup5ever=error,selectors=error";
     let filter = if verbose {
-        EnvFilter::new("webclaw=debug")
+        EnvFilter::new("webclaw=debug,html5ever=error,markup5ever=error,selectors=error")
     } else {
-        EnvFilter::try_from_env("WEBCLAW_LOG").unwrap_or_else(|_| EnvFilter::new("warn"))
+        EnvFilter::try_from_env("WEBCLAW_LOG").unwrap_or_else(|_| EnvFilter::new(default))
     };
 
     tracing_subscriber::fmt().with_env_filter(filter).init();

--- a/crates/webclaw-core/src/llm/body.rs
+++ b/crates/webclaw-core/src/llm/body.rs
@@ -73,6 +73,18 @@ pub(crate) fn process_body(markdown: &str) -> ProcessedBody {
     // d. Extract links, replace inline `[text](url)` with just `text`
     let (text, extracted_links) = links::extract_and_strip_links(&text);
 
+    // d1b. Strip bare-integer paragraphs (news-index comment counts, page
+    //      numbers). Must run AFTER link extraction so [0](#comment) collapses
+    //      to "0" first, and BEFORE dedup so identical 0 lines don't muddle
+    //      fingerprint dedup.
+    let text = cleanup::strip_bare_number_lines(&text);
+
+    // d1c. Second UI-control pass: after link extraction, lines that were
+    //      previously `[0](url) Next` now read as `0 Next` -- a pure control
+    //      line that the pre-link c3 pass couldn't see through the link
+    //      syntax.
+    let text = cleanup::strip_ui_control_text(&text);
+
     // d2. Collapse repeated adjacent phrases on the same line
     // (responsive variants: "Read more Read more Read more" -> "Read more")
     let text = dedup_repeated_phrases(&text);

--- a/crates/webclaw-core/src/llm/body.rs
+++ b/crates/webclaw-core/src/llm/body.rs
@@ -29,6 +29,9 @@ pub(crate) fn process_body(markdown: &str) -> ProcessedBody {
     // 0c. Strip leaked JavaScript (framework hydration, self.__wrap_n, etc.)
     let text = cleanup::strip_leaked_js(&text);
 
+    // 0c2. Strip a11y link chrome ("opens new tab", external link hints)
+    let text = cleanup::strip_a11y_link_chrome(&text);
+
     // 0d. Collapse spaced-out text (CSS animation artifacts like "S t a r t")
     // Must run before any dedup -- spaced text confuses word-based dedup.
     let text = cleanup::collapse_spaced_text(&text);

--- a/crates/webclaw-core/src/llm/cleanup.rs
+++ b/crates/webclaw-core/src/llm/cleanup.rs
@@ -160,7 +160,7 @@ pub(crate) fn strip_leaked_js(input: &str) -> String {
 pub(crate) fn strip_a11y_link_chrome(input: &str) -> String {
     static A11Y_PATTERN: Lazy<Regex> = Lazy::new(|| {
         Regex::new(
-            r"(?i)\s*,?\s*\b(?:opens (?:in )?(?:a )?new (?:tab|window)|opens external (?:link|website)|external link)\b\.?",
+            r"(?i)(?:\s*,\s*(?:opens (?:in )?(?:a )?new (?:tab|window)|opens external (?:link|website)|external link)\b\.?|\s+\((?:opens (?:in )?(?:a )?new (?:tab|window)|opens external (?:link|website)|external link)\)\.?|\s+external link\b\.?$)",
         )
         .unwrap()
     });
@@ -1424,13 +1424,19 @@ mod tests {
 
     #[test]
     fn a11y_preserves_code_blocks() {
-        let input = "```\nopens new tab is a function\n```\nopens new tab here";
+        let input = "```\nopens new tab is a function\n```\nDownload, opens new tab";
         let out = strip_a11y_link_chrome(input);
         assert!(
             out.contains("opens new tab is a function"),
             "code stripped: {out}"
         );
         // Outside the fence, the chrome is removed.
-        assert!(!out.ends_with("opens new tab here"));
+        assert!(!out.to_lowercase().contains("download, opens new tab"));
+    }
+
+    #[test]
+    fn a11y_preserves_external_link_prose() {
+        let input = "Researchers found an external link between the two incidents.";
+        assert_eq!(strip_a11y_link_chrome(input), input);
     }
 }

--- a/crates/webclaw-core/src/llm/cleanup.rs
+++ b/crates/webclaw-core/src/llm/cleanup.rs
@@ -395,6 +395,9 @@ pub(crate) fn is_ui_control_line(line: &str) -> bool {
 
 /// Known UI control tokens from Material Icons ligatures, icon fonts, and
 /// common navigation elements that leak into text extraction.
+///
+/// Match is case-insensitive: `Next`, `next`, and `NEXT` are all treated as
+/// pagination chrome when alone on a line.
 fn is_ui_control_token(token: &str) -> bool {
     const UI_CONTROLS: &[&str] = &[
         // Material Icons ligatures
@@ -428,6 +431,12 @@ fn is_ui_control_token(token: &str) -> bool {
         "search",
         "menu",
         "share",
+        // Pagination chrome left over from rendered "Next | Previous" links
+        "next",
+        "previous",
+        "prev",
+        "older",
+        "newer",
         // Arrow/nav characters
         "\u{2190}",
         "\u{2192}",
@@ -444,7 +453,64 @@ fn is_ui_control_token(token: &str) -> bool {
         "\u{00BB}",
         "\u{00AB}",
     ];
-    UI_CONTROLS.contains(&token)
+    let lowered = token.to_ascii_lowercase();
+    if UI_CONTROLS.contains(&lowered.as_str()) {
+        return true;
+    }
+    // Bare short integers (≤4 digits) on a line of otherwise pure control
+    // tokens are comment counts / page numbers glued to pagination chrome
+    // (e.g. "0 Next" at the bottom of news index pages). Counting these as
+    // controls lets `is_ui_control_line` strip the whole line. A legitimate
+    // line like "5 minutes" stays because "minutes" is not a control.
+    !token.is_empty() && token.len() <= 4 && token.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Remove lines that are a bare short integer alone in their paragraph.
+///
+/// News index pages often render comment counts (`0`, `42`) and pagination
+/// page numbers (`1`, `2`) as standalone paragraphs after each article. These
+/// add zero signal and confuse downstream readers, but they are real numbers
+/// not control tokens, so [`strip_ui_control_text`] doesn't catch them.
+///
+/// To stay safe, we only drop a line if BOTH conditions hold:
+/// 1. The trimmed line parses cleanly as a non-negative integer ≤ 9999.
+/// 2. The line is alone in its paragraph (surrounded by blank lines, or at
+///    document edges). A `1.` or `- 1` list marker has different trim text and
+///    is not affected.
+pub(crate) fn strip_bare_number_lines(input: &str) -> String {
+    let lines: Vec<&str> = input.lines().collect();
+    let mut out: Vec<&str> = Vec::with_capacity(lines.len());
+    let mut in_code = false;
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code = !in_code;
+            out.push(line);
+            continue;
+        }
+        if in_code {
+            out.push(line);
+            continue;
+        }
+        if is_bare_short_integer(trimmed) && is_isolated_in_paragraph(&lines, i) {
+            continue;
+        }
+        out.push(line);
+    }
+    out.join("\n")
+}
+
+fn is_bare_short_integer(s: &str) -> bool {
+    if s.is_empty() || s.len() > 4 {
+        return false;
+    }
+    s.chars().all(|c| c.is_ascii_digit())
+}
+
+fn is_isolated_in_paragraph(lines: &[&str], i: usize) -> bool {
+    let prev_blank = i == 0 || lines[i - 1].trim().is_empty();
+    let next_blank = i + 1 == lines.len() || lines[i + 1].trim().is_empty();
+    prev_blank && next_blank
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/webclaw-core/src/llm/cleanup.rs
+++ b/crates/webclaw-core/src/llm/cleanup.rs
@@ -147,6 +147,45 @@ pub(crate) fn strip_leaked_js(input: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Accessibility link chrome ("opens new tab", "external link")
+// ---------------------------------------------------------------------------
+
+/// Strip screen-reader-only link chrome that bleeds into rendered text.
+///
+/// Sites like Reuters wrap external/new-window links with hidden spans
+/// like `<span class="visually-hidden">, opens new tab</span>`. The noise
+/// filter can't reliably catch these (no consistent class hook across
+/// sites), so they end up duplicated all over the body text. This is a
+/// targeted text-level scrub of the most common phrasings.
+pub(crate) fn strip_a11y_link_chrome(input: &str) -> String {
+    static A11Y_PATTERN: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?i)\s*,?\s*\b(?:opens (?:in )?(?:a )?new (?:tab|window)|opens external (?:link|website)|external link)\b\.?",
+        )
+        .unwrap()
+    });
+
+    let mut out = String::with_capacity(input.len());
+    let mut in_code_fence = false;
+    for (i, line) in input.lines().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        if line.trim().starts_with("```") {
+            in_code_fence = !in_code_fence;
+            out.push_str(line);
+            continue;
+        }
+        if in_code_fence {
+            out.push_str(line);
+            continue;
+        }
+        out.push_str(&A11Y_PATTERN.replace_all(line, ""));
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
 // Spaced-out text collapsing (CSS animation artifacts)
 // ---------------------------------------------------------------------------
 
@@ -1355,5 +1394,43 @@ mod tests {
     fn alt_text_code_block_preserved() {
         let input = "```\nImage of something in code\n```";
         assert_eq!(strip_alt_text_noise(input), input);
+    }
+
+    #[test]
+    fn a11y_strips_opens_new_tab() {
+        let input = "Download the App, opens new tab and Subscribe, opens new tab.";
+        let out = strip_a11y_link_chrome(input);
+        assert!(!out.to_lowercase().contains("opens new tab"), "leak: {out}");
+        assert!(out.contains("Download the App"));
+        assert!(out.contains("Subscribe"));
+    }
+
+    #[test]
+    fn a11y_strips_external_link_variants() {
+        let cases = [
+            ("Visit our docs, opens external link", "Visit our docs"),
+            ("Click here, opens in a new window.", "Click here"),
+            ("More info external link", "More info"),
+        ];
+        for (input, expected_prefix) in cases {
+            let out = strip_a11y_link_chrome(input);
+            assert!(
+                out.starts_with(expected_prefix),
+                "input={input:?} got={out:?}"
+            );
+            assert!(!out.to_lowercase().contains("opens"), "leak: {out}");
+        }
+    }
+
+    #[test]
+    fn a11y_preserves_code_blocks() {
+        let input = "```\nopens new tab is a function\n```\nopens new tab here";
+        let out = strip_a11y_link_chrome(input);
+        assert!(
+            out.contains("opens new tab is a function"),
+            "code stripped: {out}"
+        );
+        // Outside the fence, the chrome is removed.
+        assert!(!out.ends_with("opens new tab here"));
     }
 }

--- a/crates/webclaw-core/src/llm/links.rs
+++ b/crates/webclaw-core/src/llm/links.rs
@@ -69,6 +69,21 @@ fn is_noise_link(text: &str, href: &str) -> bool {
         return true;
     }
 
+    // Bare-integer labels (comment counts, vote counts, page numbers). Always
+    // noise; the number alone tells the LLM nothing. Capped at 4 digits so a
+    // legitimately useful year-style label (`1999`) isn't dropped — but in
+    // practice bare 4-digit labels in a links section are page anchors, not
+    // articles, so this stays safe.
+    if !text.is_empty() && text.len() <= 4 && text.chars().all(|c| c.is_ascii_digit()) {
+        return true;
+    }
+
+    // In-page comment/discussion fragments that survived the bare-fragment check
+    // because the href is a full URL with `#comment-stream` (or similar) tail.
+    if href.contains("#comment-stream") || href.contains("#comments") || href.contains("#disqus") {
+        return true;
+    }
+
     // Internal user profile / action URLs (HN-style)
     if href.contains("/user?id=")
         || href.contains("/hide?id=")

--- a/crates/webclaw-core/src/llm/links.rs
+++ b/crates/webclaw-core/src/llm/links.rs
@@ -88,10 +88,19 @@ fn is_noise_link(text: &str, href: &str) -> bool {
 static MD_MARKERS_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"#{1,6}\s+|\*{1,2}|_{1,2}|`").unwrap());
 
+static A11Y_LABEL_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)\s*,?\s*\b(?:opens (?:in )?(?:a )?new (?:tab|window)|opens external (?:link|website)|external link)\b\.?",
+    )
+    .unwrap()
+});
+
 /// Clean a link label: strip markdown, dedup repeated phrases, truncate.
 pub(crate) fn clean_link_label(raw: &str) -> String {
     // Strip markdown markers
     let label = MD_MARKERS_RE.replace_all(raw, "").to_string();
+    // Strip a11y link chrome ("opens new tab", etc.)
+    let label = A11Y_LABEL_RE.replace_all(&label, "").to_string();
     let label = label.split_whitespace().collect::<Vec<_>>().join(" ");
 
     // Dedup repeated phrases in label

--- a/crates/webclaw-core/src/llm/links.rs
+++ b/crates/webclaw-core/src/llm/links.rs
@@ -90,7 +90,7 @@ static MD_MARKERS_RE: Lazy<Regex> =
 
 static A11Y_LABEL_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r"(?i)\s*,?\s*\b(?:opens (?:in )?(?:a )?new (?:tab|window)|opens external (?:link|website)|external link)\b\.?",
+        r"(?i)(?:\s*,?\s*(?:opens (?:in )?(?:a )?new (?:tab|window)|opens external (?:link|website))\b\.?|\s*,\s*external link\b\.?|\s+external link\b\.?$)",
     )
     .unwrap()
 });
@@ -189,5 +189,21 @@ mod tests {
         assert!(is_noise_link("5 minutes ago", "https://example.com"));
         assert!(is_noise_link("user", "https://hn.com/user?id=foo"));
         assert!(!is_noise_link("Rust docs", "https://rust-lang.org"));
+    }
+
+    #[test]
+    fn link_label_preserves_external_link_prose() {
+        assert_eq!(
+            clean_link_label("Research found an external link between incidents"),
+            "Research found an external link between incidents"
+        );
+    }
+
+    #[test]
+    fn link_label_strips_terminal_external_link_chrome() {
+        assert_eq!(
+            clean_link_label("Reuters story external link"),
+            "Reuters story"
+        );
     }
 }

--- a/crates/webclaw-core/src/llm/mod.rs
+++ b/crates/webclaw-core/src/llm/mod.rs
@@ -80,26 +80,32 @@ pub fn to_llm_text(result: &ExtractionResult, url: Option<&str>) -> String {
 /// hydration state.
 fn is_useful_structured_data(v: &serde_json::Value) -> bool {
     let Some(obj) = v.as_object() else {
+        // SvelteKit can emit compact arrays of page data. Keep those if they
+        // are small enough to be useful, while still dropping giant hydration
+        // arrays under the same budget as untyped objects.
+        if v.is_array() {
+            let serialized = serde_json::to_string(v).unwrap_or_default();
+            return serialized.len() <= 4 * 1024;
+        }
         return false;
     };
     // JSON-LD: @type drives the decision.
     if let Some(t) = obj.get("@type") {
-        let type_str = match t {
-            serde_json::Value::String(s) => s.clone(),
+        let types: Vec<String> = match t {
+            serde_json::Value::String(s) => vec![s.to_ascii_lowercase()],
             serde_json::Value::Array(a) => a
                 .iter()
                 .filter_map(|x| x.as_str())
-                .collect::<Vec<_>>()
-                .join(","),
-            _ => String::new(),
+                .map(str::to_ascii_lowercase)
+                .collect(),
+            _ => Vec::new(),
         };
-        let lower = type_str.to_ascii_lowercase();
-        // Drop low-info chrome types.
-        const DROP_TYPES: &[&str] = &["website", "webpage", "sitenavigationelement"];
-        if DROP_TYPES.iter().any(|d| lower == *d) {
+        if types.is_empty() {
             return false;
         }
-        return !lower.is_empty();
+        // Drop low-info chrome types.
+        const DROP_TYPES: &[&str] = &["website", "webpage", "sitenavigationelement"];
+        return types.iter().any(|t| !DROP_TYPES.iter().any(|d| t == d));
     }
     // Next.js pageProps / SvelteKit data without @type: keep only if compact.
     // Anything over ~4KB is almost certainly hydration state, not content.
@@ -819,6 +825,19 @@ mod tests {
         assert!(
             out.contains("## Structured Data"),
             "Compact untyped dropped: {out}"
+        );
+    }
+
+    #[test]
+    fn structured_data_keeps_compact_untyped_array() {
+        // SvelteKit can emit compact arrays rather than objects.
+        let r = make_result_with_structured(vec![serde_json::json!([
+            { "title": "Hi", "body": "small array item" }
+        ])]);
+        let out = to_llm_text(&r, None);
+        assert!(
+            out.contains("small array item"),
+            "Compact untyped array dropped: {out}"
         );
     }
 }

--- a/crates/webclaw-core/src/llm/mod.rs
+++ b/crates/webclaw-core/src/llm/mod.rs
@@ -46,13 +46,65 @@ pub fn to_llm_text(result: &ExtractionResult, url: Option<&str>) -> String {
     }
 
     // -- 4. Structured data (NEXT_DATA, SvelteKit, JSON-LD) --
-    if !result.structured_data.is_empty() {
-        out.push_str("\n\n## Structured Data\n\n```json\n");
-        out.push_str(&serde_json::to_string_pretty(&result.structured_data).unwrap_or_default());
-        out.push_str("\n```");
+    // Only emit useful items: Schema.org records with a meaningful @type,
+    // and only if the total serialized size stays under a budget. Framework
+    // hydration blobs (Next.js pageProps full of ad-targeting flags, build
+    // IDs, schedule paths) explode to hundreds of KB and drown the LLM in
+    // noise — drop them rather than ship them.
+    let useful: Vec<_> = result
+        .structured_data
+        .iter()
+        .filter(|v| is_useful_structured_data(v))
+        .cloned()
+        .collect();
+    if !useful.is_empty() {
+        let serialized = serde_json::to_string_pretty(&useful).unwrap_or_default();
+        const STRUCTURED_DATA_MAX_BYTES: usize = 16 * 1024;
+        if serialized.len() <= STRUCTURED_DATA_MAX_BYTES {
+            out.push_str("\n\n## Structured Data\n\n```json\n");
+            out.push_str(&serialized);
+            out.push_str("\n```");
+        }
     }
 
     out.trim().to_string()
+}
+
+/// Decide whether a structured-data value carries content worth emitting.
+///
+/// Schema.org records with a recognizable content `@type` (Article, NewsArticle,
+/// Product, Recipe, FAQPage, HowTo, Event, Person, Organization, BreadcrumbList,
+/// VideoObject, JobPosting, etc.) are kept. Generic `WebSite` / `WebPage` /
+/// `ItemList` records and Next.js `pageProps`-style blobs without a useful
+/// `@type` are dropped — they're almost always navigation chrome or framework
+/// hydration state.
+fn is_useful_structured_data(v: &serde_json::Value) -> bool {
+    let Some(obj) = v.as_object() else {
+        return false;
+    };
+    // JSON-LD: @type drives the decision.
+    if let Some(t) = obj.get("@type") {
+        let type_str = match t {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Array(a) => a
+                .iter()
+                .filter_map(|x| x.as_str())
+                .collect::<Vec<_>>()
+                .join(","),
+            _ => String::new(),
+        };
+        let lower = type_str.to_ascii_lowercase();
+        // Drop low-info chrome types.
+        const DROP_TYPES: &[&str] = &["website", "webpage", "sitenavigationelement"];
+        if DROP_TYPES.iter().any(|d| lower == *d) {
+            return false;
+        }
+        return !lower.is_empty();
+    }
+    // Next.js pageProps / SvelteKit data without @type: keep only if compact.
+    // Anything over ~4KB is almost certainly hydration state, not content.
+    let serialized = serde_json::to_string(v).unwrap_or_default();
+    serialized.len() <= 4 * 1024
 }
 
 // ---------------------------------------------------------------------------
@@ -699,5 +751,74 @@ mod tests {
         );
         assert!(out.contains("Some content"), "Content before lost: {out}");
         assert!(out.contains("More content"), "Content after lost: {out}");
+    }
+
+    // -- Structured-data gating tests --
+
+    fn make_result_with_structured(values: Vec<serde_json::Value>) -> ExtractionResult {
+        let mut r = make_result("# Body");
+        r.structured_data = values;
+        r
+    }
+
+    #[test]
+    fn structured_data_drops_chrome_types() {
+        // WebSite/WebPage records are framework chrome — should be dropped.
+        let r = make_result_with_structured(vec![serde_json::json!({
+            "@type": "WebSite",
+            "name": "Example",
+            "url": "https://example.com"
+        })]);
+        let out = to_llm_text(&r, None);
+        assert!(
+            !out.contains("## Structured Data"),
+            "WebSite chrome leaked into output: {out}"
+        );
+    }
+
+    #[test]
+    fn structured_data_keeps_article_types() {
+        let r = make_result_with_structured(vec![serde_json::json!({
+            "@type": "NewsArticle",
+            "headline": "Big news",
+            "datePublished": "2026-05-10"
+        })]);
+        let out = to_llm_text(&r, None);
+        assert!(
+            out.contains("## Structured Data"),
+            "NewsArticle dropped: {out}"
+        );
+        assert!(out.contains("Big news"));
+    }
+
+    #[test]
+    fn structured_data_drops_oversized_blob() {
+        // 32KB pageProps-style blob with no @type — should be dropped.
+        let big = "x".repeat(32 * 1024);
+        let r = make_result_with_structured(vec![serde_json::json!({
+            "buildId": "abc",
+            "isFallback": false,
+            "noise": big
+        })]);
+        let out = to_llm_text(&r, None);
+        assert!(
+            !out.contains("## Structured Data"),
+            "Oversized untyped blob leaked: len={}",
+            out.len()
+        );
+    }
+
+    #[test]
+    fn structured_data_keeps_compact_untyped() {
+        // Small untyped record (e.g. a parsed pageProps with real content) — keep.
+        let r = make_result_with_structured(vec![serde_json::json!({
+            "title": "Hi",
+            "body": "small enough to keep"
+        })]);
+        let out = to_llm_text(&r, None);
+        assert!(
+            out.contains("## Structured Data"),
+            "Compact untyped dropped: {out}"
+        );
     }
 }

--- a/crates/webclaw-core/src/llm/mod.rs
+++ b/crates/webclaw-core/src/llm/mod.rs
@@ -51,12 +51,17 @@ pub fn to_llm_text(result: &ExtractionResult, url: Option<&str>) -> String {
     // hydration blobs (Next.js pageProps full of ad-targeting flags, build
     // IDs, schedule paths) explode to hundreds of KB and drown the LLM in
     // noise — drop them rather than ship them.
-    let useful: Vec<_> = result
+    let mut useful: Vec<_> = result
         .structured_data
         .iter()
         .filter(|v| is_useful_structured_data(v))
         .cloned()
         .collect();
+    // Scrub body-duplicating fields so the article body doesn't ship twice
+    // (once as rendered markdown, again inside JSON-LD `articleBody`).
+    for v in &mut useful {
+        scrub_body_fields(v);
+    }
     if !useful.is_empty() {
         let serialized = serde_json::to_string_pretty(&useful).unwrap_or_default();
         const STRUCTURED_DATA_MAX_BYTES: usize = 16 * 1024;
@@ -111,6 +116,46 @@ fn is_useful_structured_data(v: &serde_json::Value) -> bool {
     // Anything over ~4KB is almost certainly hydration state, not content.
     let serialized = serde_json::to_string(v).unwrap_or_default();
     serialized.len() <= 4 * 1024
+}
+
+/// Recursively remove fields whose value is a long body string already
+/// rendered as markdown in the main output.
+///
+/// Schema.org `NewsArticle` / `Article` records often embed the full article
+/// body inside `articleBody`. Emitting that alongside the rendered markdown
+/// ships the same content twice and wastes the LLM's context budget. We
+/// always strip `articleBody`, and additionally strip `body` / `text` /
+/// `description` when their value is ≥ 500 chars (short blurbs are kept
+/// because they carry signal that may not be in the rendered body).
+fn scrub_body_fields(v: &mut serde_json::Value) {
+    const BODY_KEYS: &[&str] = &["articleBody"];
+    const LONG_BODY_KEYS: &[&str] = &["body", "text", "description"];
+    const LONG_THRESHOLD: usize = 500;
+    match v {
+        serde_json::Value::Object(map) => {
+            map.retain(|k, val| {
+                if BODY_KEYS.contains(&k.as_str()) {
+                    return false;
+                }
+                if LONG_BODY_KEYS.contains(&k.as_str())
+                    && let Some(s) = val.as_str()
+                    && s.len() >= LONG_THRESHOLD
+                {
+                    return false;
+                }
+                true
+            });
+            for child in map.values_mut() {
+                scrub_body_fields(child);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for child in arr.iter_mut() {
+                scrub_body_fields(child);
+            }
+        }
+        _ => {}
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/webclaw-core/src/markdown.rs
+++ b/crates/webclaw-core/src/markdown.rs
@@ -320,6 +320,9 @@ fn children_to_md(
                 }
             }
             Node::Text(text) => {
+                if !text.is_empty() && !out.is_empty() && needs_separator(&out, text) {
+                    out.push(' ');
+                }
                 out.push_str(text);
             }
             _ => {}
@@ -350,6 +353,9 @@ fn inline_text(
                 }
             }
             Node::Text(text) => {
+                if !text.is_empty() && !out.is_empty() && needs_separator(&out, text) {
+                    out.push(' ');
+                }
                 out.push_str(text);
             }
             _ => {}
@@ -1604,6 +1610,20 @@ mod tests {
         assert!(
             output.contains("      return;"),
             "collapse_whitespace stripped 6-space indent: {output}"
+        );
+    }
+
+    #[test]
+    fn text_after_inline_element_keeps_separator() {
+        // Reuters-style markup: <a><time>3h</time>ago</a><a>Tanker crosses...</a>
+        // The "ago" text node sits between two element children. Without a
+        // separator check on the Text branch, "ago" + "Tanker" would smash
+        // together as "agoTanker".
+        let html = r#"<div><span>3h</span>ago<span>Tanker crosses Strait</span></div>"#;
+        let (md, _, _) = convert_html(html, None);
+        assert!(
+            !md.contains("agoTanker"),
+            "Element->Text->Element smashed together: {md}"
         );
     }
 }

--- a/crates/webclaw-core/src/markdown.rs
+++ b/crates/webclaw-core/src/markdown.rs
@@ -367,11 +367,65 @@ fn inline_text(
 
 /// Check whether a space is needed between two adjacent chunks of output.
 /// Returns true when the left side doesn't end with whitespace and the right
-/// side doesn't start with whitespace — i.e., two words would be mashed together.
+/// side doesn't start with whitespace, except around punctuation that should
+/// bind to the adjacent token.
 fn needs_separator(left: &str, right: &str) -> bool {
-    let l = left.as_bytes().last().copied().unwrap_or(b' ');
-    let r = right.as_bytes().first().copied().unwrap_or(b' ');
-    !l.is_ascii_whitespace() && !r.is_ascii_whitespace()
+    let l = left.chars().next_back().unwrap_or(' ');
+    let r = right.chars().next().unwrap_or(' ');
+
+    if l.is_whitespace() || r.is_whitespace() {
+        return false;
+    }
+
+    // Do not create "word ," / "word )" / "word 's" artifacts.
+    if is_closing_punctuation(r) {
+        return false;
+    }
+
+    // Do not create "( word" / "[ 1" artifacts.
+    if is_opening_punctuation(l) {
+        return false;
+    }
+
+    // Common inline-code suffixes: `Option`s, `x`'s. Treat them like a
+    // single token rather than separating the text node.
+    if matches!(l, '`' | ')') && starts_with_inline_code_suffix(right) {
+        return false;
+    }
+
+    true
+}
+
+fn starts_with_inline_code_suffix(s: &str) -> bool {
+    let trimmed = s.trim_start_matches(['*', '_']);
+    let mut chars = trimmed.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    if matches!(first, '\'' | '’') {
+        return true;
+    }
+
+    if !matches!(first, 's' | 'S') {
+        return false;
+    }
+
+    match chars.next() {
+        None => true,
+        Some(c) => c.is_whitespace() || is_closing_punctuation(c) || matches!(c, '*' | '_'),
+    }
+}
+
+fn is_closing_punctuation(c: char) -> bool {
+    matches!(
+        c,
+        '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '%' | '\'' | '’' | '"' | '”'
+    )
+}
+
+fn is_opening_punctuation(c: char) -> bool {
+    matches!(c, '(' | '[' | '{' | '"' | '“')
 }
 
 /// Collect raw text content (no markdown formatting).
@@ -1624,6 +1678,27 @@ mod tests {
         assert!(
             !md.contains("agoTanker"),
             "Element->Text->Element smashed together: {md}"
+        );
+    }
+
+    #[test]
+    fn punctuation_after_inline_element_stays_attached() {
+        let html = r#"<p><span>Hello</span>, world. Use <code>package.json</code>.</p>"#;
+        let (md, _, _) = convert_html(html, None);
+        assert!(md.contains("Hello, world"), "punctuation detached: {md}");
+        assert!(
+            md.contains("`package.json`."),
+            "code punctuation detached: {md}"
+        );
+    }
+
+    #[test]
+    fn inline_code_suffix_stays_attached() {
+        let html = r#"<p><a href="https://example.com"><code>NullPointerException</code></a><em>s</em> are common.</p>"#;
+        let (md, _, _) = convert_html(html, None);
+        assert!(
+            md.contains("[`NullPointerException`](https://example.com)*s* are common"),
+            "code suffix detached: {md}"
         );
     }
 }


### PR DESCRIPTION
Five small fixes I ran into while using webclaw across a multi-site news sweep. Each is independent; happy to split if you'd prefer separate PRs.

**html5ever stderr spam.** Real-world pages with malformed HTML trigger `WARN html5ever::tree_builder: foster parenting not implemented` dozens of times per fetch. Tightened the default `EnvFilter` in `init_logging` to silence `html5ever` / `markup5ever` / `selectors` at WARN level. `WEBCLAW_LOG` still overrides.

**GDPR consent-wall detection.** Yahoo Finance (and Google/Oath sites) redirect EU clients to `consent.yahoo.com/v2/collectConsent?...` which returns 3 words of locale-specific text. webclaw passes that through silently today. Added `EmptyReason::ConsentWall` and `is_consent_wall()` that checks the final URL host against `consent.*`, `/consent/`, `collectConsent`, etc., plus a small set of English title prefixes. Prints a warning suggesting `--proxy` or `--cookie`. Detection only, no automatic bypass.

**Bare-integer paragraphs.** News index pages render comment counts and page numbers as their own paragraph (`0` between every article on ZeroHedge). Added `strip_bare_number_lines` in `cleanup.rs`, wired into the body pipeline after link extraction so `[0](url#comment-stream)` collapses to `0` first.

**Pagination tokens glued to counts.** Lines like `0 Next` survived both passes because neither token alone is a control word, and `Next` is capitalized. Made `is_ui_control_token` case-insensitive, added pagination words (`next`, `prev`, `previous`, `older`, `newer`) to `UI_CONTROLS`, and treated bare <=4-digit integers as control tokens so glued lines are stripped without catching real prose like "5 minutes" (which has the non-control token "minutes").

**JSON-LD `articleBody` duplication.** Business Insider's structured-data block includes the full article body in `articleBody`, which then ships alongside the rendered markdown. The same content goes to the LLM twice. Added `scrub_body_fields` in `llm/mod.rs` that always strips `articleBody` and strips `body` / `text` / `description` when their value is >=500 chars (short blurbs are kept because they carry signal that may not be in the rendered body).

Also extended `is_noise_link` in `links.rs` to drop bare-digit link labels and `#comment-stream` / `#comments` / `#disqus` fragment hrefs, since the body cleanup doesn't help the deduplicated Links section at the bottom of the output.

### Verification

All 292 core tests pass. `cargo fmt --check --all` clean. `cargo clippy --all -- -D warnings` clean on the files I touched. The pre-existing `uninlined_format_args` warnings in `brand.rs` are still there but I left them as-is, per the existing CLAUDE.md note about CI using an older toolchain.

Re-ran the five problematic pages end-to-end:

- MarketWatch: 60 lines of html5ever WARN to 0
- Yahoo Finance: silent 3-word output to consent-wall warning with remediation hint
- ZeroHedge body: bare `0` between every article plus `0 Next` at tail to 0
- ZeroHedge Links section: dozens of `- 0: ...#comment-stream` entries to 0
- Business Insider: `articleBody` duplicated in structured data to scrubbed

Control sites (Reuters 531w, Bloomberg 334w, FT 1289w, Investing.com 1305w) unchanged.

### Out of scope

Two issues from the same sweep I didn't try to fix:

- CNBC's `/bonds/` returns ~90% marketing-shell ("Best Credit Cards", podcast lists, etc.) because the live yield tickers are JS-rendered. Correct fix is `--browser chrome`, not an extraction tweak.
- Business Insider's AI-summary widget questions ("How does QE affect bond yields?") leak into the markdown body. Would need a site-specific selector or a generic `<details>`-collapse heuristic.

Also intentionally not included: actual consent-wall bypass via pre-baked accept cookies for Yahoo/Google. Detection is a contained safe change; cookie injection is a separate feature with its own maintenance surface and is better discussed in its own PR.
