### PR TITLE
chore: release v0.6.9 (fix multi-arch Docker publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,29 +172,32 @@ jobs:
           done
           ls -laR binaries-*/
 
-      # Build per-arch images with plain docker build (no buildx manifest nesting)
+      # Build each arch with buildx (the docker-container driver from
+      # setup-buildx-action), pushing straight to the registry. Plain
+      # `docker build --push` uses the legacy docker driver, whose GHCR push
+      # path intermittently fails with "ERROR: unknown blob"; buildx's registry
+      # exporter does not. The multi-arch list is then assembled registry-side
+      # with `imagetools create` (no local manifest store, so no blob races).
       - name: Build and push
         run: |
           tag="${GITHUB_REF#refs/tags/}"
 
           # amd64
-          docker build -f Dockerfile.ci --build-arg BINARY_DIR=binaries-x86_64-unknown-linux-gnu \
+          docker buildx build -f Dockerfile.ci --build-arg BINARY_DIR=binaries-x86_64-unknown-linux-gnu \
             --platform linux/amd64 -t ghcr.io/0xmassi/webclaw:${tag}-amd64 --push .
 
           # arm64
-          docker build -f Dockerfile.ci --build-arg BINARY_DIR=binaries-aarch64-unknown-linux-gnu \
+          docker buildx build -f Dockerfile.ci --build-arg BINARY_DIR=binaries-aarch64-unknown-linux-gnu \
             --platform linux/arm64 -t ghcr.io/0xmassi/webclaw:${tag}-arm64 --push .
 
-          # Multi-arch manifest
-          docker manifest create ghcr.io/0xmassi/webclaw:${tag} \
+          # Multi-arch manifest list, assembled from the already-pushed per-arch tags
+          docker buildx imagetools create -t ghcr.io/0xmassi/webclaw:${tag} \
             ghcr.io/0xmassi/webclaw:${tag}-amd64 \
             ghcr.io/0xmassi/webclaw:${tag}-arm64
-          docker manifest push ghcr.io/0xmassi/webclaw:${tag}
 
-          docker manifest create ghcr.io/0xmassi/webclaw:latest \
+          docker buildx imagetools create -t ghcr.io/0xmassi/webclaw:latest \
             ghcr.io/0xmassi/webclaw:${tag}-amd64 \
             ghcr.io/0xmassi/webclaw:${tag}-arm64
-          docker manifest push ghcr.io/0xmassi/webclaw:latest
 
   homebrew:
     name: Update Homebrew

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.6.9] - 2026-06-10
+
+### Fixed
+- The multi-arch Docker image (linux/amd64 + linux/arm64) now publishes reliably on each release. The build moved to Buildx so registry pushes no longer fail intermittently, and the Homebrew formula update that depends on it is no longer skipped.
+
 ## [0.6.8] - 2026-06-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-cli"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "clap",
  "dotenvy",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-core"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "ego-tree",
  "once_cell",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-fetch"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-llm"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-mcp"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "dirs",
  "dotenvy",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-pdf"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "pdf-extract",
  "thiserror",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-server"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.6.8"
+version = "0.6.9"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/0xMassi/webclaw"


### PR DESCRIPTION
Switches the release Docker job from `docker build --push` (legacy docker driver, intermittent `unknown blob` on GHCR) to `docker buildx build --push` + `docker buildx imagetools create` for the manifest list. Unblocks the Homebrew job (`needs: [release, docker]`). Version bump only; no library/CLI changes.