### PR TITLE
ci(release): build Linux binaries on ubuntu-22.04 for older-glibc support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,16 @@ jobs:
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
+          # Linux targets pin to ubuntu-22.04 (glibc 2.35), NOT ubuntu-latest
+          # (24.04 = glibc 2.39): glibc is forward- but not backward-compatible,
+          # so binaries built on 24.04 require GLIBC_2.38 and won't start on
+          # older LTS distros (Debian 12, Ubuntu 22.04). The aarch64 cross
+          # toolchain tracks the runner's distro too, so this lowers both
+          # targets. See #73. Don't bump to ubuntu-latest.
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - target: x86_64-pc-windows-msvc
             os: windows-latest
 


### PR DESCRIPTION
Partially addresses #73.

## Problem
Linux release binaries were built on `ubuntu-latest` (now Ubuntu 24.04, glibc 2.39), so they required `GLIBC_2.38` and failed to start on older LTS distros:

```
libc.so.6: version `GLIBC_2.38' not found (required by webclaw-mcp)
```

glibc is forward- but not backward-compatible, so the **build host's glibc sets the floor**.

## Change
Pin both Linux build-matrix targets to `ubuntu-22.04` (glibc 2.35). The aarch64 target cross-compiles using the runner's apt toolchain, so its target glibc tracks the runner distro too — this lowers **both** x86_64 and aarch64.

Only the two build-matrix `os:` values change. The orchestration jobs (checksums, Homebrew) keep `ubuntu-latest` since their glibc is irrelevant.

## Coverage after this

| Distro | glibc | Before (2.38) | After (2.35) |
|--------|-------|:---:|:---:|
| Debian 12 (bookworm) | 2.36 | ❌ | ✅ |
| Ubuntu 22.04 LTS | 2.35 | ❌ | ✅ |
| Amazon Linux 2023 | 2.34 | ❌ | ❌ |
| RHEL 9 / Rocky 9 | 2.34 | ❌ | ❌ |

`ubuntu-20.04` (glibc 2.31) would cover the 2.34 distros, but GitHub retired that runner in 2025, so 22.04 is the practical floor. **Full coverage (Amazon Linux 2023, RHEL 9, anything older) needs a musl static build** — that remains tracked in #73.

## Note
Takes effect on the **next release tag** — existing `v0.6.13` assets are unchanged until a new release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)