### PR TITLE
ci(release): add musl static Linux builds (glibc-independent)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,14 @@ jobs:
             os: ubuntu-22.04
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04
+          # musl static builds: glibc-independent, run on ANY Linux (Alpine,
+          # Amazon Linux 2023, RHEL 9, old distros) where the gnu builds can't.
+          # cargo-zigbuild links statically, so the host glibc is irrelevant —
+          # ubuntu-latest is fine. See #73.
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
 
@@ -84,8 +92,30 @@ jobs:
           choco install nasm -y
           echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      # musl static builds use zig as the C/C++ cross-compiler for BoringSSL,
+      # driven by cargo-zigbuild. Build scripts (bindgen) still run as the glibc
+      # host so libclang loads fine; the linked output is fully static and runs
+      # on any Linux regardless of glibc. (A native Alpine build can't do this —
+      # its static build scripts can't dlopen libclang.)
+      - name: Setup zig + cargo-zigbuild (musl)
+        if: contains(matrix.target, 'musl')
+        run: |
+          python3 -m pip install --user --break-system-packages ziglang
+          mkdir -p "$HOME/.local/bin"
+          printf '#!/bin/sh\nexec python3 -m ziglang "$@"\n' > "$HOME/.local/bin/zig"
+          chmod +x "$HOME/.local/bin/zig"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/zig" version
+          cargo install cargo-zigbuild --locked
+
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        shell: bash
+        run: |
+          if [[ "${{ matrix.target }}" == *-musl ]]; then
+            cargo zigbuild --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
 
       - name: Package
         shell: bash


### PR DESCRIPTION
Closes #73.

## Why
After #74 the gnu Linux binaries are floored at glibc 2.35 — still won't run on **Amazon Linux 2023 / RHEL 9 (glibc 2.34)**, Alpine, or anything older. This adds **fully static musl builds** that run on *any* Linux regardless of glibc.

## What
Adds `x86_64-unknown-linux-musl` + `aarch64-unknown-linux-musl` to the release build matrix, built with **`cargo-zigbuild`** (zig as the C/C++ cross-compiler for BoringSSL).

Key insight from investigating #73: a *native* Alpine build doesn't work — rust:alpine compiles build-scripts as static-musl, and a static binary can't `dlopen` libclang, so `bindgen` dies. Cross-compiling from a glibc host fixes it: build-scripts run as glibc (libclang loads), only the final artifact is linked static-musl.

musl assets ship **alongside** the gnu ones (gnu stays the default — musl's allocator/DNS resolver are a bit slower for a network-heavy workload; musl is the runs-anywhere fallback). Downstream jobs need no changes: `release` globs `*.tar.gz` so musl assets are checksummed + uploaded automatically, while `docker`/`homebrew` enumerate gnu targets explicitly and ignore musl.

## Validation (Docker)
Built `webclaw-mcp` for `aarch64-unknown-linux-musl` via `cargo zigbuild` — fully static (`ldd: not a dynamic executable`, zero `NEEDED` libs), then ran it with a real MCP `initialize` handshake across:

| Distro | libc | Static musl |
|--------|------|:---:|
| Alpine 3.20 | musl | ✅ PASS |
| Debian 11 | glibc 2.31 | ✅ PASS |
| Debian 12 | glibc 2.36 | ✅ PASS |
| Amazon Linux 2023 | glibc 2.34 | ✅ PASS |
| Ubuntu 24.04 | glibc 2.39 | ✅ PASS |

Runs everywhere, including where both the current release and the #74 glibc-2.35 build fail.

## ⚠️ Caveat
The `build` job only runs on **tag push**, so this YAML couldn't be exercised by PR CI. The build *mechanism* (cargo-zigbuild → static musl, incl. BoringSSL) is Docker-validated above, but the exact runner steps (zig install via `pip ziglang`, `cargo install cargo-zigbuild`) run for real only on the **first tagged release** — worth watching that release run, or cutting a throwaway `v*-rc` tag to confirm before relying on it.

## Follow-up (optional, not in this PR)
Teach `create-webclaw` to fall back to the musl asset when the host glibc is < 2.35, so AL2023 / RHEL 9 users get a working auto-install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)