### PR TITLE
ci(release): guard prerelease tags from clobbering :latest / Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,11 +176,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"
+          # SemVer prerelease tags (e.g. v1.2.3-rc1) contain a hyphen — mark
+          # them as prereleases so they never surface as the stable release.
+          prerelease=""
+          case "$tag" in *-*) prerelease="--prerelease" ;; esac
           gh release create "$tag" \
             artifacts/*.tar.gz \
             artifacts/*.zip \
             artifacts/SHA256SUMS \
             --repo "$GITHUB_REPOSITORY" \
+            $prerelease \
             --generate-notes
 
   docker:
@@ -239,18 +244,25 @@ jobs:
       - name: Build and push
         run: |
           tag="${{ steps.tag.outputs.tag }}"
+          # Only move :latest for stable tags. Prereleases (hyphenated, e.g.
+          # v1.2.3-rc1) still publish :${tag} for testing but must not clobber
+          # :latest.
+          latest=""
+          case "$tag" in *-*) ;; *) latest="-t ghcr.io/0xmassi/webclaw:latest" ;; esac
           docker buildx build -f Dockerfile.ci \
             --platform linux/amd64,linux/arm64 \
             --provenance=false --sbom=false \
             -t "ghcr.io/0xmassi/webclaw:${tag}" \
-            -t ghcr.io/0xmassi/webclaw:latest \
+            $latest \
             --push .
 
   homebrew:
     name: Update Homebrew
     needs: [release, docker]
     # Runs once Docker succeeds, on both tag push and manual re-publish.
-    if: ${{ always() && needs.docker.result == 'success' }}
+    # Skipped for prereleases (hyphenated tags like v1.2.3-rc1) so the formula
+    # keeps pointing at the latest stable, never an rc.
+    if: ${{ always() && needs.docker.result == 'success' && !contains(github.event.inputs.tag || github.ref_name, '-') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Prep for cutting validation rc tags (e.g. to exercise the new musl build job from #75) without shipping an rc to stable users.

## Problem
Any `v*` tag runs the full release pipeline. For a prerelease like `v0.6.14-rc1` that meant:
- a normal (non-prerelease) GitHub Release,
- `ghcr.io/0xmassi/webclaw:latest` **overwritten** with the rc image,
- the Homebrew formula **repointed** to the rc (so `brew install webclaw` gets it).

## Fix
Guard all three on the SemVer prerelease hyphen (`v1.2.3-rc1` contains `-`):
- **release**: add `--prerelease` for hyphenated tags.
- **docker**: still push `:${tag}` (so the rc image is testable) but only move `:latest` for stable tags.
- **homebrew**: skip the job entirely for prereleases.

Stable tags (`v0.6.14`) are unaffected — verified the shell hyphen-detection both ways. Pure CI change; the build/test jobs are untouched.