### PR TITLE
chore(release): bump version to 0.6.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.6.14] - 2026-06-27
+
+A distribution release: the extraction engine is unchanged from 0.6.13, but the
+Linux binaries now run on far more systems.
+
+### Added
+- **Static musl Linux binaries** (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`) that run on any Linux regardless of glibc — Alpine, Amazon Linux 2023, RHEL 9, and older distros. Built with cargo-zigbuild and shipped alongside the existing gnu binaries.
+
+### Changed
+- **gnu Linux binaries now run on older glibc.** They are built on Ubuntu 22.04 (glibc 2.35) instead of the latest runner (glibc 2.39), so they start on Debian 12, Ubuntu 22.04, and other LTS distros that previously failed with `version 'GLIBC_2.38' not found`.
+
+### Fixed
+- **`create-webclaw` install (`create-webclaw@0.1.5`)** failed on every platform: it looked up the wrong release-asset name and used `unzip` (absent on Windows), silently falling back to `cargo install`. It now downloads the correct versioned asset, extracts via PowerShell on Windows, lifts the binary out of the archive's versioned subdirectory, and surfaces GitHub API rate-limit errors instead of hiding them.
+- **Self-hosting setup scripts** wrote `WEBCLAW_AUTH_KEY` into the generated `.env`, but the server reads `WEBCLAW_API_KEY` — on a public bind this made the server refuse to start. `setup.sh` and `deploy/hetzner.sh` now write the correct variable.
+
 ## [0.6.13] - 2026-06-17
 
 ### Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-cli"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "clap",
  "dotenvy",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-core"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "ego-tree",
  "once_cell",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-fetch"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-llm"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-mcp"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "dirs",
  "dotenvy",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-pdf"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "pdf-extract",
  "thiserror",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-server"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.6.13"
+version = "0.6.14"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/0xMassi/webclaw"


### PR DESCRIPTION
Release **v0.6.14** — a distribution release. The extraction engine is unchanged from 0.6.13 (`git diff v0.6.13..main -- crates/` is empty); what changed is how the Linux binaries are built + a couple of fixes.

## Included since v0.6.13
- **Static musl Linux binaries** (#75) — run on any Linux regardless of glibc (Alpine, Amazon Linux 2023, RHEL 9). Validated in CI on the rc: both targets build + are fully static.
- **gnu binaries built on glibc 2.35** (#74) — run on Debian 12 / Ubuntu 22.04 (previously failed with `GLIBC_2.38 not found`).
- **Prerelease guards** (#76) — rc tags no longer touch `:latest` / Homebrew (validated end-to-end via v0.6.14-rc1).
- **`create-webclaw` install fix** (#72, `create-webclaw@0.1.5`) — repaired the broken Windows/all-platform binary install.
- **Self-hosting env fix** (#68) — `setup.sh` / `hetzner.sh` now write `WEBCLAW_API_KEY`.

## Changes here
- `Cargo.toml`: workspace version `0.6.13` → `0.6.14`
- `Cargo.lock`: 7 webclaw crates synced (no other deps touched)
- `CHANGELOG.md`: `[0.6.14]` entry

After merge, tagging `v0.6.14` triggers the release workflow (gnu + musl assets, `:latest`, Homebrew).