### PR TITLE
docs(readme): switch Star History chart to shieldcn

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,11 +481,11 @@ Thanks to everyone improving webclaw through issues, examples, docs, bug reports
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=0xMassi%2Fwebclaw&type=date&legend=top-left">
+<a href="https://github.com/0xMassi/webclaw/stargazers">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=0xMassi/webclaw&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=0xMassi/webclaw&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=0xMassi/webclaw&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/chart/github/stars/0xMassi/webclaw.svg?mode=dark&theme=zinc&bg=transparent&border=false&logo=false&icon=Star" />
+   <source media="(prefers-color-scheme: light)" srcset="https://shieldcn.dev/chart/github/stars/0xMassi/webclaw.svg?mode=light&theme=zinc&bg=transparent&border=false&logo=false&icon=Star" />
+   <img alt="Star History Chart" src="https://shieldcn.dev/chart/github/stars/0xMassi/webclaw.svg?mode=light&theme=zinc&bg=transparent&border=false&logo=false&icon=Star" />
  </picture>
 </a>
 


### PR DESCRIPTION
Swaps the README **Star History** chart from `star-history.com` to shieldcn's chart endpoint (`shieldcn.dev/chart/github/stars/0xMassi/webclaw.svg`).

Why: shieldcn already powers the stars badge in the README header, so this consolidates on a single chart/badge provider. shieldcn added a star-history chart (visible on their own repo), using params `theme=zinc&bg=transparent&border=false&logo=false&icon=Star`.

- Keeps the responsive light/dark `<picture>` (`mode=dark` / `mode=light`); both verified `200 image/svg+xml`.
- Link now points to `/stargazers` (shieldcn has no interactive page like star-history.com), consistent with the existing stars badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)