### PR TITLE
fix(cli): hide secret env values in --help output

### DIFF
--- a/crates/webclaw-cli/src/main.rs
+++ b/crates/webclaw-cli/src/main.rs
@@ -183,11 +183,11 @@ struct Cli {
     browser: Browser,
 
     /// Proxy URL (http://user:pass@host:port or socks5://host:port)
-    #[arg(short, long, env = "WEBCLAW_PROXY")]
+    #[arg(short, long, env = "WEBCLAW_PROXY", hide_env_values = true)]
     proxy: Option<String>,
 
     /// File with proxies (host:port:user:pass, one per line). Rotates per request.
-    #[arg(long, env = "WEBCLAW_PROXY_FILE")]
+    #[arg(long, env = "WEBCLAW_PROXY_FILE", hide_env_values = true)]
     proxy_file: Option<String>,
 
     /// Request timeout in seconds
@@ -256,7 +256,7 @@ struct Cli {
 
     /// Webhook URL: POST a JSON payload when an operation completes.
     /// Works with crawl, batch, watch (on change), and single URL modes.
-    #[arg(long, env = "WEBCLAW_WEBHOOK_URL")]
+    #[arg(long, env = "WEBCLAW_WEBHOOK_URL", hide_env_values = true)]
     webhook: Option<String>,
 
     /// Extract brand identity (colors, fonts, logo)
@@ -347,12 +347,12 @@ struct Cli {
     llm_model: Option<String>,
 
     /// Override the LLM base URL (Ollama, OpenAI-compatible, or Anthropic-compatible)
-    #[arg(long, env = "WEBCLAW_LLM_BASE_URL")]
+    #[arg(long, env = "WEBCLAW_LLM_BASE_URL", hide_env_values = true)]
     llm_base_url: Option<String>,
 
     // -- Cloud API options --
     /// Webclaw Cloud API key for automatic fallback on bot-protected or JS-rendered sites
-    #[arg(long, env = "WEBCLAW_API_KEY")]
+    #[arg(long, env = "WEBCLAW_API_KEY", hide_env_values = true)]
     api_key: Option<String>,
 
     /// Force all requests through the cloud API (skip local extraction)
@@ -436,7 +436,7 @@ enum Commands {
         query: String,
 
         /// Serper.dev API key. Falls back to the `SERPER_API_KEY` env var.
-        #[arg(long, env = "SERPER_API_KEY")]
+        #[arg(long, env = "SERPER_API_KEY", hide_env_values = true)]
         serper_key: Option<String>,
 
         /// Number of results to return (1-10).

--- a/crates/webclaw-server/src/main.rs
+++ b/crates/webclaw-server/src/main.rs
@@ -57,7 +57,7 @@ struct Args {
     /// `/v1/*` request must present `Authorization: Bearer <key>`.
     /// When unset, the server runs in open mode (no auth) — only
     /// safe on a local-bound interface or behind another auth layer.
-    #[arg(long, env = "WEBCLAW_API_KEY")]
+    #[arg(long, env = "WEBCLAW_API_KEY", hide_env_values = true)]
     api_key: Option<String>,
 
     /// Tracing filter. Env: RUST_LOG.


### PR DESCRIPTION
## Problem
clap renders the **current value** of an arg's `env` var in `--help` by default. For anyone who has the secret set in their environment, `webclaw --help` prints it in the clear:

```
--api-key <API_KEY>  [env: WEBCLAW_API_KEY=wc_************************]
```

## Fix
Add `hide_env_values = true` to every arg backed by a credential-bearing env var. `--help` now shows the variable **name** only:

```
--api-key <API_KEY>  [env: WEBCLAW_API_KEY]
```

Covered args:
- **CLI** (`webclaw-cli`): `WEBCLAW_API_KEY`, `SERPER_API_KEY`, `WEBCLAW_PROXY`, `WEBCLAW_PROXY_FILE`, `WEBCLAW_WEBHOOK_URL`, `WEBCLAW_LLM_BASE_URL`
- **Server** (`webclaw-server`): `WEBCLAW_API_KEY`

## Verified
- Builds clean (`cargo build -p webclaw-cli -p webclaw-server`).
- `cargo fmt --check` passes.
- Ran `--help` with dummy secret env values set: variable names show, values do not; `0` occurrences of the dummy value in help output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)