### PR TITLE
docs(readme): add "Use as an agent skill" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,22 @@ Extract the brand colors, fonts, and logos from this company website.
 
 ---
 
+## Use as an agent skill
+
+Add webclaw to Claude Code, Cursor, Windsurf, and other MCP agents in one command:
+
+```bash
+npx skills add 0xMassi/webclaw-skill
+```
+
+Your agent gets scrape, crawl, map, extract, summarize, diff, brand, and search
+as native tools. Most sites extract locally with no API key. Set `WEBCLAW_API_KEY`
+to handle bot-protected and JavaScript-rendered pages.
+
+Find it on [skills.sh](https://www.skills.sh/0xMassi/webclaw-skill/webclaw).
+
+---
+
 ## Tools
 
 | Tool | What it does | Local |


### PR DESCRIPTION
Adds a **Use as an agent skill** section to the core README, right after the MCP Server section, promoting the one-command skills.sh install:

```
npx skills add 0xMassi/webclaw-skill
```

Copy is stop-slopped (no em dashes, active voice). Notes the keyless-by-default local path and the optional `WEBCLAW_API_KEY` upgrade for bot-protected / JS-rendered pages, and links the skills.sh page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)