### PR TITLE
chore(registry): reword server.json description (drop competitor name), bump 0.6.17

### DIFF
--- a/packages/create-webclaw/server.json
+++ b/packages/create-webclaw/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.0xMassi/webclaw",
   "title": "webclaw",
-  "description": "Turn any URL into clean markdown/JSON for AI agents. Self-hostable Firecrawl alternative.",
-  "version": "0.6.16",
+  "description": "Turn any URL into clean markdown/JSON for AI agents. Self-hostable web content extraction.",
+  "version": "0.6.17",
   "packages": [
     {
       "registryType": "npm",


### PR DESCRIPTION
Syncs the repo with what's now live on the MCP registry (`io.github.0xMassi/webclaw@0.6.17`).

- **Description** reworded from "Self-hostable Firecrawl alternative" → "Self-hostable web content extraction" (drops the competitor name per the public-scrubbing posture). 90 chars, under the registry's 100-char limit.
- **`version`** 0.6.16 → 0.6.17 (registry rejects republishing the same version).
- **`packages[].version`** intentionally stays 0.6.16 — it must reference the `@webclaw/mcp` version that actually exists on npm; the registry validates that (and validated clean).

Already published; this PR just tracks it in git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)