### PR TITLE
feat(llm): add Atlas Cloud as an opt-in provider

### DIFF
--- a/crates/webclaw-cli/src/main.rs
+++ b/crates/webclaw-cli/src/main.rs
@@ -2265,7 +2265,7 @@ async fn build_llm_provider(cli: &Cli) -> Result<Box<dyn LlmProvider>, String> {
         let chain = webclaw_llm::ProviderChain::default().await;
         if chain.is_empty() {
             return Err(
-                "no LLM providers available -- start Ollama or set OPENAI_API_KEY / ATLASCLOUD_API_KEY / ANTHROPIC_API_KEY"
+                "no LLM providers available -- start Ollama or set OPENAI_API_KEY / ANTHROPIC_API_KEY"
                     .into(),
             );
         }

--- a/crates/webclaw-cli/src/main.rs
+++ b/crates/webclaw-cli/src/main.rs
@@ -338,7 +338,7 @@ struct Cli {
     #[arg(long, num_args = 0..=1, default_missing_value = "3")]
     summarize: Option<usize>,
 
-    /// Force a specific LLM provider (ollama, openai, anthropic)
+    /// Force a specific LLM provider (ollama, openai, atlascloud, anthropic)
     #[arg(long, env = "WEBCLAW_LLM_PROVIDER")]
     llm_provider: Option<String>,
 
@@ -2239,6 +2239,14 @@ async fn build_llm_provider(cli: &Cli) -> Result<Box<dyn LlmProvider>, String> {
                 .ok_or("OPENAI_API_KEY not set")?;
                 Ok(Box::new(provider))
             }
+            "atlascloud" => {
+                let provider = webclaw_llm::providers::atlascloud::AtlasCloudProvider::new(
+                    None,
+                    cli.llm_model.clone(),
+                )
+                .ok_or("ATLASCLOUD_API_KEY not set")?;
+                Ok(Box::new(provider))
+            }
             "anthropic" => {
                 let provider = webclaw_llm::providers::anthropic::AnthropicProvider::with_base_url(
                     None,
@@ -2249,14 +2257,14 @@ async fn build_llm_provider(cli: &Cli) -> Result<Box<dyn LlmProvider>, String> {
                 Ok(Box::new(provider))
             }
             other => Err(format!(
-                "unknown LLM provider: {other} (use ollama, openai, or anthropic)"
+                "unknown LLM provider: {other} (use ollama, openai, atlascloud, or anthropic)"
             )),
         }
     } else {
         let chain = webclaw_llm::ProviderChain::default().await;
         if chain.is_empty() {
             return Err(
-                "no LLM providers available -- start Ollama or set OPENAI_API_KEY / ANTHROPIC_API_KEY"
+                "no LLM providers available -- start Ollama or set OPENAI_API_KEY / ATLASCLOUD_API_KEY / ANTHROPIC_API_KEY"
                     .into(),
             );
         }

--- a/crates/webclaw-cli/src/main.rs
+++ b/crates/webclaw-cli/src/main.rs
@@ -2242,6 +2242,7 @@ async fn build_llm_provider(cli: &Cli) -> Result<Box<dyn LlmProvider>, String> {
             "atlascloud" => {
                 let provider = webclaw_llm::providers::atlascloud::AtlasCloudProvider::new(
                     None,
+                    cli.llm_base_url.clone(),
                     cli.llm_model.clone(),
                 )
                 .ok_or("ATLASCLOUD_API_KEY not set")?;

--- a/crates/webclaw-llm/src/chain.rs
+++ b/crates/webclaw-llm/src/chain.rs
@@ -1,5 +1,5 @@
 /// Provider chain — tries providers in order until one succeeds.
-/// Default order: Ollama (local, free) -> OpenAI -> Atlas Cloud -> Gemini -> Anthropic.
+/// Default order: Ollama (local, free) -> OpenAI -> Gemini -> Anthropic.
 /// Only includes providers that are actually configured/available.
 use async_trait::async_trait;
 use tracing::{debug, warn};
@@ -7,8 +7,8 @@ use tracing::{debug, warn};
 use crate::error::LlmError;
 use crate::provider::{CompletionRequest, LlmProvider};
 use crate::providers::{
-    anthropic::AnthropicProvider, atlascloud::AtlasCloudProvider, gemini::GeminiProvider,
-    ollama::OllamaProvider, openai::OpenAiProvider,
+    anthropic::AnthropicProvider, gemini::GeminiProvider, ollama::OllamaProvider,
+    openai::OpenAiProvider,
 };
 
 pub struct ProviderChain {
@@ -16,7 +16,7 @@ pub struct ProviderChain {
 }
 
 impl ProviderChain {
-    /// Build the default chain: Ollama -> OpenAI -> Atlas Cloud -> Gemini -> Anthropic.
+    /// Build the default chain: Ollama -> OpenAI -> Gemini -> Anthropic.
     /// Ollama is always added (availability checked at call time).
     /// Cloud providers are only added if their API keys are configured.
     /// Gemini sits ahead of Anthropic so Google Cloud credits are preferred,
@@ -35,11 +35,6 @@ impl ProviderChain {
         if let Some(openai) = OpenAiProvider::new(None, None, None) {
             debug!("openai configured, adding to chain");
             providers.push(Box::new(openai));
-        }
-
-        if let Some(atlascloud) = AtlasCloudProvider::new(None, None, None) {
-            debug!("atlascloud configured, adding to chain");
-            providers.push(Box::new(atlascloud));
         }
 
         if let Some(gemini) = GeminiProvider::new(None, None, None) {

--- a/crates/webclaw-llm/src/chain.rs
+++ b/crates/webclaw-llm/src/chain.rs
@@ -37,7 +37,7 @@ impl ProviderChain {
             providers.push(Box::new(openai));
         }
 
-        if let Some(atlascloud) = AtlasCloudProvider::new(None, None) {
+        if let Some(atlascloud) = AtlasCloudProvider::new(None, None, None) {
             debug!("atlascloud configured, adding to chain");
             providers.push(Box::new(atlascloud));
         }

--- a/crates/webclaw-llm/src/chain.rs
+++ b/crates/webclaw-llm/src/chain.rs
@@ -1,5 +1,5 @@
 /// Provider chain — tries providers in order until one succeeds.
-/// Default order: Ollama (local, free) -> OpenAI -> Gemini -> Anthropic.
+/// Default order: Ollama (local, free) -> OpenAI -> Atlas Cloud -> Gemini -> Anthropic.
 /// Only includes providers that are actually configured/available.
 use async_trait::async_trait;
 use tracing::{debug, warn};
@@ -7,8 +7,8 @@ use tracing::{debug, warn};
 use crate::error::LlmError;
 use crate::provider::{CompletionRequest, LlmProvider};
 use crate::providers::{
-    anthropic::AnthropicProvider, gemini::GeminiProvider, ollama::OllamaProvider,
-    openai::OpenAiProvider,
+    anthropic::AnthropicProvider, atlascloud::AtlasCloudProvider, gemini::GeminiProvider,
+    ollama::OllamaProvider, openai::OpenAiProvider,
 };
 
 pub struct ProviderChain {
@@ -16,7 +16,7 @@ pub struct ProviderChain {
 }
 
 impl ProviderChain {
-    /// Build the default chain: Ollama -> OpenAI -> Gemini -> Anthropic.
+    /// Build the default chain: Ollama -> OpenAI -> Atlas Cloud -> Gemini -> Anthropic.
     /// Ollama is always added (availability checked at call time).
     /// Cloud providers are only added if their API keys are configured.
     /// Gemini sits ahead of Anthropic so Google Cloud credits are preferred,
@@ -35,6 +35,11 @@ impl ProviderChain {
         if let Some(openai) = OpenAiProvider::new(None, None, None) {
             debug!("openai configured, adding to chain");
             providers.push(Box::new(openai));
+        }
+
+        if let Some(atlascloud) = AtlasCloudProvider::new(None, None) {
+            debug!("atlascloud configured, adding to chain");
+            providers.push(Box::new(atlascloud));
         }
 
         if let Some(gemini) = GeminiProvider::new(None, None, None) {

--- a/crates/webclaw-llm/src/providers/atlascloud.rs
+++ b/crates/webclaw-llm/src/providers/atlascloud.rs
@@ -12,10 +12,14 @@ pub struct AtlasCloudProvider {
 
 impl AtlasCloudProvider {
     /// Returns `None` if no Atlas Cloud API key is available (param or env).
-    pub fn new(key_override: Option<String>, model: Option<String>) -> Option<Self> {
+    pub fn new(
+        key_override: Option<String>,
+        base_url: Option<String>,
+        model: Option<String>,
+    ) -> Option<Self> {
         let key = super::load_api_key(key_override, "ATLASCLOUD_API_KEY")?;
-        let base_url = std::env::var("ATLASCLOUD_BASE_URL")
-            .ok()
+        let base_url = base_url
+            .or_else(|| std::env::var("ATLASCLOUD_BASE_URL").ok())
             .unwrap_or_else(|| "https://api.atlascloud.ai/v1".into());
         let model = model.unwrap_or_else(|| "qwen/qwen3.5-flash".into());
         let inner = OpenAiProvider::new(Some(key), Some(base_url), Some(model))?;
@@ -48,12 +52,12 @@ mod tests {
 
     #[test]
     fn empty_key_returns_none() {
-        assert!(AtlasCloudProvider::new(Some(String::new()), None).is_none());
+        assert!(AtlasCloudProvider::new(Some(String::new()), None, None).is_none());
     }
 
     #[test]
     fn explicit_key_constructs_with_atlas_defaults() {
-        let provider = AtlasCloudProvider::new(Some("test-key".into()), None)
+        let provider = AtlasCloudProvider::new(Some("test-key".into()), None, None)
             .expect("should construct");
         assert_eq!(provider.name(), "atlascloud");
         assert_eq!(provider.default_model(), "qwen/qwen3.5-flash");
@@ -63,6 +67,7 @@ mod tests {
     fn explicit_model_override() {
         let provider = AtlasCloudProvider::new(
             Some("test-key".into()),
+            Some("https://proxy.example.com/v1".into()),
             Some("deepseek-ai/deepseek-v4-pro".into()),
         )
         .expect("should construct");

--- a/crates/webclaw-llm/src/providers/atlascloud.rs
+++ b/crates/webclaw-llm/src/providers/atlascloud.rs
@@ -57,8 +57,8 @@ mod tests {
 
     #[test]
     fn explicit_key_constructs_with_atlas_defaults() {
-        let provider = AtlasCloudProvider::new(Some("test-key".into()), None, None)
-            .expect("should construct");
+        let provider =
+            AtlasCloudProvider::new(Some("test-key".into()), None, None).expect("should construct");
         assert_eq!(provider.name(), "atlascloud");
         assert_eq!(provider.default_model(), "qwen/qwen3.5-flash");
     }

--- a/crates/webclaw-llm/src/providers/atlascloud.rs
+++ b/crates/webclaw-llm/src/providers/atlascloud.rs
@@ -1,0 +1,71 @@
+/// Atlas Cloud provider — OpenAI-compatible chat completions with Atlas defaults.
+use async_trait::async_trait;
+
+use crate::error::LlmError;
+use crate::provider::{CompletionRequest, LlmProvider};
+
+use super::openai::OpenAiProvider;
+
+pub struct AtlasCloudProvider {
+    inner: OpenAiProvider,
+}
+
+impl AtlasCloudProvider {
+    /// Returns `None` if no Atlas Cloud API key is available (param or env).
+    pub fn new(key_override: Option<String>, model: Option<String>) -> Option<Self> {
+        let key = super::load_api_key(key_override, "ATLASCLOUD_API_KEY")?;
+        let base_url = std::env::var("ATLASCLOUD_BASE_URL")
+            .ok()
+            .unwrap_or_else(|| "https://api.atlascloud.ai/v1".into());
+        let model = model.unwrap_or_else(|| "qwen/qwen3.5-flash".into());
+        let inner = OpenAiProvider::new(Some(key), Some(base_url), Some(model))?;
+        Some(Self { inner })
+    }
+
+    pub fn default_model(&self) -> &str {
+        self.inner.default_model()
+    }
+}
+
+#[async_trait]
+impl LlmProvider for AtlasCloudProvider {
+    async fn complete(&self, request: &CompletionRequest) -> Result<String, LlmError> {
+        self.inner.complete(request).await
+    }
+
+    async fn is_available(&self) -> bool {
+        self.inner.is_available().await
+    }
+
+    fn name(&self) -> &str {
+        "atlascloud"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_key_returns_none() {
+        assert!(AtlasCloudProvider::new(Some(String::new()), None).is_none());
+    }
+
+    #[test]
+    fn explicit_key_constructs_with_atlas_defaults() {
+        let provider = AtlasCloudProvider::new(Some("test-key".into()), None)
+            .expect("should construct");
+        assert_eq!(provider.name(), "atlascloud");
+        assert_eq!(provider.default_model(), "qwen/qwen3.5-flash");
+    }
+
+    #[test]
+    fn explicit_model_override() {
+        let provider = AtlasCloudProvider::new(
+            Some("test-key".into()),
+            Some("deepseek-ai/deepseek-v4-pro".into()),
+        )
+        .expect("should construct");
+        assert_eq!(provider.default_model(), "deepseek-ai/deepseek-v4-pro");
+    }
+}

--- a/crates/webclaw-llm/src/providers/mod.rs
+++ b/crates/webclaw-llm/src/providers/mod.rs
@@ -1,4 +1,5 @@
 pub mod anthropic;
+pub mod atlascloud;
 pub mod gemini;
 pub mod ollama;
 pub mod openai;


### PR DESCRIPTION
Supersedes #87 (that PR's branch was based on a stale main and would revert recent merges). This preserves **@nb213's** original commits (cherry-picked onto current main) plus one adjustment per maintainer decision.

## What
Adds an **Atlas Cloud** LLM provider — a thin newtype over the existing OpenAI-compatible `OpenAiProvider` (base URL `https://api.atlascloud.ai/v1`, default model `qwen/qwen3.5-flash`, `ATLASCLOUD_API_KEY` / `ATLASCLOUD_BASE_URL`).

Reachable **explicitly** via `--llm-provider atlascloud` (or `WEBCLAW_LLM_PROVIDER=atlascloud`). **Opt-in only** — deliberately **not** auto-added to the default `ProviderChain`, so setting `ATLASCLOUD_API_KEY` never silently reroutes CLI/MCP/server traffic to a 3rd-party aggregator. (This is the one change vs #87, which auto-inserted it ahead of Gemini.)

## Verified (not assumed)
- **Atlas Cloud is real** — `api.atlascloud.ai/v1` is live + OpenAI-compatible; `qwen/qwen3.5-flash` exists character-for-character in the live `GET /v1/models` (1M context, $0.10/$0.40 per 1M tokens). The `qwen/` prefix is the canonical ID — don't drop it.
- **Builds + tests** — `cargo test -p webclaw-llm`: 59 passed (incl. 3 new atlascloud tests); `cargo check -p webclaw-cli`; `fmt` + `clippy -D warnings` clean.
- Net diff: `atlascloud.rs` (new) + `mod.rs` registration + `main.rs` explicit branch. `chain.rs` net-unchanged.

## Follow-up (separate, not in this PR)
Doc strings that list provider env keys (server `summarize.rs`/`extract.rs`, mcp `server.rs`, README) are unaffected since Atlas isn't a default provider.

Co-authored-by: nb213 <binyangzhu000@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)