### PR TITLE
docs(readme): add Trendshift trending badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
 </p>
 
 <p align="center">
+  <a href="https://trendshift.io/repositories/24218?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-24218" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/24218/daily?language=Rust" alt="0xMassi/webclaw | Trendshift" width="250" height="55"/></a>
+</p>
+
+<p align="center">
   <img src="assets/demo.gif" alt="webclaw extracting clean markdown from a page" width="760" />
 </p>
 


### PR DESCRIPTION
Adds the [Trendshift](https://trendshift.io/repositories/24218) daily-trending badge to the README header (centered, its own row above the demo gif, alongside the existing badges). Docs-only. Cleaned the image alt text (`0xMassi/webclaw`, was URL-encoded `%2F`).