### PR TITLE
fix: stop treating Cloudflare's JS-detection beacon as a challenge + add Chronopost vertical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to webclaw are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+- **Chronopost parcel tracking extractor.** `webclaw vertical chronopost <tracking-url>` (also auto-detected by `webclaw <url>`, the `vertical_scrape` MCP tool, and `POST /v1/scrape/chronopost`) returns the current status, the milestone progress bar, and the full scan-event history as typed JSON. The tracking page itself renders its content after load, so a plain fetch of it returns an empty document — this extractor reads the underlying data directly.
+
+### Fixed
+- **Healthy Cloudflare-fronted pages are no longer mistaken for challenge pages.** Cloudflare adds a small JavaScript-detection snippet to ordinary, successfully served pages. webclaw matched on part of that snippet's path, so any page carrying it was treated as a bot challenge and needlessly escalated to the cloud API — which then reported an unsolvable challenge that was never there. Detection now keys on markers that only appear on a real interstitial.
+
 ## [0.6.16] - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
-- **Chronopost parcel tracking extractor.** `webclaw vertical chronopost <tracking-url>` (also auto-detected by `webclaw <url>`, the `vertical_scrape` MCP tool, and `POST /v1/scrape/chronopost`) returns the current status, the milestone progress bar, and the full scan-event history as typed JSON. The tracking page itself renders its content after load, so a plain fetch of it returns an empty document — this extractor reads the underlying data directly.
+- **Chronopost parcel tracking extractor.** `webclaw vertical chronopost <tracking-url>` — also available as the `vertical_scrape` MCP tool and `POST /v1/scrape/chronopost` — returns the current status, the milestone progress bar, and the full scan-event history as typed JSON. The tracking page itself renders its content after load, so a plain fetch of it returns an empty document; this extractor reads the underlying data directly.
 
 ### Fixed
-- **Healthy Cloudflare-fronted pages are no longer mistaken for challenge pages.** Cloudflare adds a small JavaScript-detection snippet to ordinary, successfully served pages. webclaw matched on part of that snippet's path, so any page carrying it was treated as a bot challenge and needlessly escalated to the cloud API — which then reported an unsolvable challenge that was never there. Detection now keys on markers that only appear on a real interstitial.
+- **Healthy Cloudflare-fronted pages are no longer mistaken for challenge pages.** Cloudflare adds a small JavaScript-detection snippet to ordinary, successfully served pages. webclaw matched on part of that snippet's path, so any page carrying it was treated as a bot challenge and needlessly escalated to the cloud API — which then reported an unsolvable challenge that was never there. Detection now keys on markers that only appear on a real interstitial, and covers both path forms the snippet is served under.
 
 ## [0.6.16] - 2026-07-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Three binaries: `webclaw` (CLI), `webclaw-mcp` (MCP server), `webclaw-server` (R
 - `fetcher.rs` — the public `Fetcher` trait (`Send + Sync`). Vertical extractors take `&dyn Fetcher`, not `&FetchClient`.
 - `browser.rs` — `BrowserProfile`/`BrowserVariant` enums only (Chrome, ChromeMacos, Firefox, Safari, SafariIos26, Edge). No version numbers live here.
 - `tls.rs` — the real fingerprint builder: per-variant wreq `Emulation` (cipher/sigalg/curve lists, TLS extension order, HTTP/2 SETTINGS, header wire-order). Browser versions are set HERE: Chrome 145, Firefox 135, Edge 145, Safari 18.3.1, Safari iOS 26. SafariIos26 composes on top of `wreq_util::Profile::SafariIos26`. SSRF-safe redirect policy lives here too.
-- `extractors/` — ~30 vertical site extractors (Amazon, eBay, GitHub, Instagram, LinkedIn, Reddit, YouTube, npm, PyPI, HuggingFace, Etsy, Shopify, WooCommerce, Trustpilot, arXiv, Hacker News, StackOverflow, ...); `extractors/mod.rs` is the dispatch table. All reach the network through `&dyn Fetcher`. Shared helpers (not verticals themselves): `extractors/og.rs` (single-pass Open Graph `og:*` parser, `raw()` vs `unescaped()`), `extractors/github_common.rs` (shared GitHub API fetch + status handling), `extractors/jsonld_product.rs` / `ecommerce_product.rs` (shared JSON-LD product walker reused by the e-commerce verticals).
+- `extractors/` — ~30 vertical site extractors (Amazon, eBay, GitHub, Instagram, LinkedIn, Reddit, YouTube, npm, PyPI, HuggingFace, Etsy, Shopify, WooCommerce, Trustpilot, arXiv, Hacker News, StackOverflow, Chronopost, ...); `extractors/mod.rs` is the dispatch table. Note `dispatch_by_url` (auto-detect) deliberately excludes the permissive e-commerce/substack matchers — only add an extractor there when its `matches()` is strict enough that it cannot steal a generic URL. All reach the network through `&dyn Fetcher`. Shared helpers (not verticals themselves): `extractors/og.rs` (single-pass Open Graph `og:*` parser, `raw()` vs `unescaped()`), `extractors/github_common.rs` (shared GitHub API fetch + status handling), `extractors/jsonld_product.rs` / `ecommerce_product.rs` (shared JSON-LD product walker reused by the e-commerce verticals).
 - `reddit.rs` / `linkedin.rs` — top-level fetch-side verticals (distinct from `extractors/` and from `webclaw-core`'s parsers): `reddit.rs` rewrites Reddit hosts to `old.reddit.com` (the `*.json` API is blocked) so `webclaw-core::reddit` can parse server-rendered HTML; `linkedin.rs` reconstructs post + comments from the SPA's HTML-escaped JSON in `<code>` tags (the `included` typed-entity array).
 - `progress.rs` — wraps a slow fetch future in `tokio::select!` against an interval, emitting a periodic `# webclaw: still fetching <URL> (Ns)` line to STDERR.
 - `crawler.rs` — BFS same-origin crawler with configurable depth/concurrency/delay
@@ -96,7 +96,7 @@ Three binaries: `webclaw` (CLI), `webclaw-mcp` (MCP server), `webclaw-server` (R
 - **Core has ZERO network dependencies** — takes `&str` HTML, returns structured output. Keep it WASM-compatible. The `quickjs` feature (default ON) pulls in rquickjs, which links a C lib and can't target wasm32; it's gated `cfg(not(target_arch = "wasm32"))` in `lib.rs`. CI compiles webclaw-core for wasm32 both with AND without default features — never ungate that.
 - **webclaw-fetch pins wreq exactly**: `wreq = "=6.0.0-rc.29"` + `wreq-util = "=3.0.0-rc.12"` (BoringSSL). The `=` pin is deliberate — these are release candidates with no semver stability between rc.N builds. No `[patch.crates-io]` forks needed; wreq handles TLS internally.
 - **No build flags in `.cargo/config.toml`** (it is comments-only) — don't add any locally. BUT CI (`.github/workflows/ci.yml`, `deps.yml`) DOES export `RUSTFLAGS: "--cfg reqwest_unstable"` for the wreq path; don't remove it from CI.
-- **webclaw-llm uses plain reqwest**. LLM APIs don't need TLS fingerprinting, so no wreq dep.
+- **webclaw-llm uses plain reqwest**. LLM APIs don't need TLS fingerprinting, so no wreq dep. `webclaw-fetch` also carries a reqwest dep, but only for `cloud.rs` (`CloudClient` → api.webclaw.io) — every *target-site* fetch must go through the wreq `FetchClient`. Don't reach for reqwest in the fetch path.
 - **Vertical extractors take `&dyn Fetcher`**, not `&FetchClient`. This lets the production server plug in a `ProductionFetcher` that adds domain_hints routing and antibot escalation on top of the same wreq client.
 - **qwen3 thinking tags** (`<think>`) are stripped at both provider and consumer levels.
 
@@ -104,10 +104,24 @@ Three binaries: `webclaw` (CLI), `webclaw-mcp` (MCP server), `webclaw-server` (R
 
 ```bash
 cargo build --release           # All three binaries (webclaw, webclaw-mcp, webclaw-server)
-cargo test --workspace          # All tests
+cargo test --workspace          # All tests (see the bench_1k caveat below)
 cargo test -p webclaw-core      # Core only
 cargo test -p webclaw-llm       # LLM only
+
+# Single test / one module — tests are inline `#[cfg(test)]` mods, so filter by name:
+cargo test -p webclaw-core noise            # every test whose name contains "noise"
+cargo test -p webclaw-core -- --exact <module>::tests::<fn_name>   # exactly one test
+cargo test -p webclaw-fetch --lib -- --nocapture   # unit tests only, print stdout
 ```
+
+⚠️ **`cargo test --workspace` runs a live 1000-site network benchmark.**
+`crates/webclaw-fetch/tests/bench_1k.rs::bench_1k_sites` is a plain
+`#[tokio::test]` (not `#[ignore]`) that fetches every URL in the tracked
+`targets_1000.txt`. It's the only integration test in the workspace; everything
+else is inline unit tests. For a fast offline loop use `--lib`:
+`cargo test --workspace --lib`. Run the benchmark deliberately instead:
+`cargo test -p webclaw-fetch --test bench_1k --release -- --nocapture`
+(honors `TARGETS_FILE` and the proxy env vars).
 
 CI (`.github/workflows/ci.yml`, with `RUSTFLAGS=--cfg reqwest_unstable`) runs four jobs — match them locally before pushing:
 - `cargo test --workspace`
@@ -117,7 +131,7 @@ CI (`.github/workflows/ci.yml`, with `RUSTFLAGS=--cfg reqwest_unstable`) runs fo
 
 ## Repo Layout & Packaging
 
-Workspace is version **0.6.15**, edition **2024**, license **AGPL-3.0** (matters for the public-OSS scrubbing rules). No crate declares `rust-version`, so MSRV is implicit — edition 2024 floors it at Rust 1.85+; CI pins `dtolnay/rust-toolchain@stable`.
+Workspace is version **0.6.16** (single source of truth: `[workspace.package] version` in the root `Cargo.toml`; all crates inherit it), edition **2024**, license **AGPL-3.0** (matters for the public-OSS scrubbing rules). No crate declares `rust-version`, so MSRV is implicit — edition 2024 floors it at Rust 1.85+; CI pins `dtolnay/rust-toolchain@stable`.
 
 Artifacts outside `crates/` that need separate attention:
 - `packages/create-webclaw/` — `npx create-webclaw` Node scaffolder that installs/configures the MCP server for AI agents (Claude, Cursor, Windsurf, ...). Versioned independently (own `package.json`) — bump it separately when MCP setup changes.
@@ -176,6 +190,17 @@ webclaw --file page.html
 cat page.html | webclaw --stdin
 ```
 
+The bare-URL form above is the default path (`command: Option<Commands>` is
+`None`, and the flag-based flow runs). There are also four **subcommands** for
+flows that don't fit that model (`Commands` enum in `webclaw-cli/src/main.rs`):
+
+```bash
+webclaw extractors --json                  # catalog of vertical extractors (same data as GET /v1/extractors)
+webclaw vertical reddit <url> --raw        # run one vertical by name → typed JSON
+webclaw search "<query>" --num 5 --scrape  # Serper.dev search (BYO key)
+webclaw bench <url> --json --facts benchmarks/facts.json   # token/bytes/time vs raw HTML
+```
+
 ## Key Thresholds
 
 - Scoring minimum: 50 chars text length
@@ -200,13 +225,51 @@ Add to Claude Desktop config (`~/Library/Application Support/Claude/claude_deskt
 
 ## Skills
 
+Repo-local, under `.claude/skills/`:
+
 - `/scrape <url>` — extract content from a URL
-- `/benchmark [url]` — run extraction performance benchmarks
-- `/research <url>` — deep web research via crawl + extraction
 - `/crawl <url>` — crawl a website
+- `/research <url>` — deep web research via crawl + extraction
+- `/benchmark [url]` — extraction quality benchmarks (webclaw vs. WebFetch)
 - `/commit` — conventional commit with change analysis
+- `/add-site` — debug + fix extraction for a site webclaw handles poorly
+- `/noise-debug` — investigate false positives/negatives in `noise.rs`
+- `/test-extraction` — quick single-URL quality check after touching the extractor
+
+## Release
+
+Cutting a release is a **tag push** — `.github/workflows/release.yml` does the rest.
+Bump `[workspace.package] version` in the root `Cargo.toml`, commit, then push
+`vX.Y.Z`. Jobs, in order:
+
+1. `build` — cross-compiles 7 targets. Linux gnu targets are pinned to
+   `ubuntu-22.04` on purpose (glibc 2.35 — building on 24.04 emits a
+   `GLIBC_2.38` requirement that won't start on Debian 12 / Ubuntu 22.04, see
+   issue #73). Don't bump those to `ubuntu-latest`. musl targets build with
+   cargo-zigbuild and are glibc-independent.
+2. `release` — publishes the GitHub release + binary assets.
+3. `npm`, `docker`, `homebrew` — consume the release assets.
+
+`workflow_dispatch` with an existing tag re-runs only `docker` (+ `homebrew`)
+against already-published assets — use it to re-push an image without cutting a
+version.
+
+`packages/create-webclaw/` has its **own** `package.json` version (currently
+0.1.7) and is bumped separately from the workspace.
 
 ## Git
 
 - Remote: `git@github.com:0xMassi/webclaw.git`
-- Use `/commit` skill for commits
+- Three long-lived branches: `dev` → `staging` → `main`. Promote up, never
+  sideways; never push straight to `main`, and never delete `dev`/`staging`.
+  Ship via PR (open → check → merge).
+- **Downstream consumers pin core by git tag**, not branch (`tag = "vX.Y.Z"`).
+  So core's `dev`/`staging` branches are a local workflow convention only —
+  anything a consumer needs must land on `main` **and be tagged**. (Note the
+  name collision: `crates/webclaw-server` here is the OSS self-host binary; the
+  hosted api.webclaw.io service is a separate private repo that depends on this
+  one.)
+- Use the `/commit` skill for commits.
+- Before pushing to this repo, scan the diff — it's public-OSS-bound (AGPL-3.0).
+  No proxy/provider names, antibot mechanics, VPS/Tailscale details, keys, or
+  private roadmap notes. Use generic user-facing wording in `CHANGELOG.md`.

--- a/crates/webclaw-fetch/src/cloud.rs
+++ b/crates/webclaw-fetch/src/cloud.rs
@@ -396,8 +396,16 @@ async fn parse_cloud_response(resp: reqwest::Response) -> Result<Value, CloudErr
 pub fn is_bot_protected(html: &str, headers: &HeaderMap) -> bool {
     let html_lower = html.to_lowercase();
 
-    // Cloudflare challenge page.
-    if html_lower.contains("_cf_chl_opt") || html_lower.contains("challenge-platform") {
+    // Cloudflare challenge page. `_cf_chl_opt` is the challenge options blob
+    // and `challenge-platform/h/` is the orchestrate script a real
+    // interstitial loads.
+    //
+    // NOT a bare `challenge-platform` match: Cloudflare injects its benign
+    // JS-detection beacon (`/cdn-cgi/challenge-platform/scripts/jsd/main.js`,
+    // paired with `__CF$cv$params`) into ordinary 200 responses, so matching
+    // the bare path flagged healthy Cloudflare-fronted pages as challenges
+    // and escalated them to the cloud API for nothing.
+    if html_lower.contains("_cf_chl_opt") || html_lower.contains("challenge-platform/h/") {
         return true;
     }
 
@@ -663,6 +671,30 @@ mod tests {
     fn is_bot_protected_detects_cloudflare_challenge() {
         let html = "<html><body>_cf_chl_opt loaded</body></html>";
         assert!(is_bot_protected(html, &empty_headers()));
+    }
+
+    #[test]
+    fn is_bot_protected_detects_cloudflare_orchestrate_script() {
+        let html = r#"<html><body><script
+            src="/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1?ray=abc">
+            </script></body></html>"#;
+        assert!(is_bot_protected(html, &empty_headers()));
+    }
+
+    #[test]
+    fn is_bot_protected_ignores_cloudflare_jsd_beacon() {
+        // Regression (chronopost.fr): Cloudflare injects its JS-detection
+        // beacon into ordinary 200 pages. This is the real markup that page
+        // serves — it is NOT an interstitial, and flagging it escalated a
+        // healthy fetch to the cloud API, which then reported an unsolvable
+        // challenge that did not exist.
+        let html = r#"<html><head><script>window.__CF$cv$params={
+            r:'a22db83e59720e29',t:'MTc4NTM0NDg0NA=='};
+            var a=document.createElement('script');
+            a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';
+            document.getElementsByTagName('head')[0].appendChild(a);
+            </script></head><body>Track your parcel</body></html>"#;
+        assert!(!is_bot_protected(html, &empty_headers()));
     }
 
     #[test]

--- a/crates/webclaw-fetch/src/cloud.rs
+++ b/crates/webclaw-fetch/src/cloud.rs
@@ -400,8 +400,9 @@ pub fn is_bot_protected(html: &str, headers: &HeaderMap) -> bool {
     // the real interstitial loads
     // `/cdn-cgi/challenge-platform/h/{b,g}/orchestrate/chl_page/v1?ray=…`.
     //
-    // `orchestrate/chl_page` is the whole discriminator, and it has to be
-    // this specific. Each looser form flags healthy pages:
+    // The orchestrate script must be matched as ONE contiguous path, and it
+    // has to include the `h/{b,g}` segment. Every looser form flags healthy
+    // pages:
     //   - `challenge-platform` and `challenge-platform/h/` both match the
     //     benign JS-detection beacon Cloudflare injects into ordinary 200
     //     responses, served under `/cdn-cgi/challenge-platform/scripts/jsd/
@@ -411,10 +412,16 @@ pub fn is_bot_protected(html: &str, headers: &HeaderMap) -> bool {
     //     on github.com, pypi.org and IBM's watsonx docs all contain it.
     //   - even `/cdn-cgi/challenge-platform/` AND `/orchestrate/` as separate
     //     substrings co-occur on a Cloudflare-fronted docs site that links to
-    //     `/docs/orchestrate/…`, which is exactly what a workflow-tool site
-    //     looks like.
-    // One contiguous literal avoids all three.
-    if html_lower.contains("_cf_chl_opt") || html_lower.contains("orchestrate/chl_page") {
+    //     `/docs/orchestrate/…`, which is what a workflow-tool site looks like.
+    // Matching the endpoint name instead (`orchestrate/chl_page`) is too
+    // narrow the other way: `orchestrate/jsch/v1` (JS challenge) and
+    // `orchestrate/managed/v1` (managed challenge) are equally real. Keying
+    // on the `h/{b,g}/orchestrate/` prefix covers every variant while still
+    // rejecting the beacon, which always sits under `/scripts/`.
+    if html_lower.contains("_cf_chl_opt")
+        || html_lower.contains("challenge-platform/h/b/orchestrate/")
+        || html_lower.contains("challenge-platform/h/g/orchestrate/")
+    {
         return true;
     }
 
@@ -742,6 +749,25 @@ mod tests {
         headers.insert("cf-mitigated", "challenge".parse().expect("valid header"));
         let html = "<html><body>Sorry, you have been blocked</body></html>";
         assert!(is_bot_protected(html, &headers));
+    }
+
+    #[test]
+    fn is_bot_protected_detects_all_orchestrate_challenge_variants() {
+        // `chl_page` is not the only orchestration endpoint — `jsch/v1` (JS
+        // challenge) and `managed/v1` (managed challenge) are equally real.
+        // Each must be caught by the path arm ALONE, without relying on
+        // `_cf_chl_opt` also being present.
+        for path in [
+            "/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1?ray=9a1",
+            "/cdn-cgi/challenge-platform/h/g/orchestrate/jsch/v1?ray=9a1",
+            "/cdn-cgi/challenge-platform/h/b/orchestrate/managed/v1?ray=9a1",
+        ] {
+            let html = format!(r#"<html><body><script src="{path}"></script></body></html>"#);
+            assert!(
+                is_bot_protected(&html, &empty_headers()),
+                "challenge variant must be detected: {path}"
+            );
+        }
     }
 
     #[test]

--- a/crates/webclaw-fetch/src/cloud.rs
+++ b/crates/webclaw-fetch/src/cloud.rs
@@ -396,16 +396,20 @@ async fn parse_cloud_response(resp: reqwest::Response) -> Result<Value, CloudErr
 pub fn is_bot_protected(html: &str, headers: &HeaderMap) -> bool {
     let html_lower = html.to_lowercase();
 
-    // Cloudflare challenge page. `_cf_chl_opt` is the challenge options blob
-    // and `challenge-platform/h/` is the orchestrate script a real
-    // interstitial loads.
+    // Cloudflare challenge page. `_cf_chl_opt` is the challenge options blob;
+    // `/orchestrate/` is the script a real interstitial loads
+    // (`/cdn-cgi/challenge-platform/h/{b,g}/orchestrate/chl_page/v1?ray=…`).
     //
-    // NOT a bare `challenge-platform` match: Cloudflare injects its benign
-    // JS-detection beacon (`/cdn-cgi/challenge-platform/scripts/jsd/main.js`,
-    // paired with `__CF$cv$params`) into ordinary 200 responses, so matching
-    // the bare path flagged healthy Cloudflare-fronted pages as challenges
-    // and escalated them to the cloud API for nothing.
-    if html_lower.contains("_cf_chl_opt") || html_lower.contains("challenge-platform/h/") {
+    // Matching any looser form of `challenge-platform` is wrong: Cloudflare
+    // injects a benign JS-detection beacon into ordinary 200 responses, and it
+    // is served under BOTH the short path
+    // (`/cdn-cgi/challenge-platform/scripts/jsd/main.js`) and the hashed one
+    // (`/cdn-cgi/challenge-platform/h/g/scripts/jsd/<hash>/main.js`). So
+    // neither `challenge-platform` nor `challenge-platform/h/` discriminates —
+    // both flag healthy pages and burn a cloud escalation on a challenge that
+    // was never there. `/orchestrate/` appears only on the real interstitial;
+    // the beacon always sits under `/scripts/`.
+    if html_lower.contains("_cf_chl_opt") || html_lower.contains("/orchestrate/") {
         return true;
     }
 
@@ -678,6 +682,27 @@ mod tests {
         let html = r#"<html><body><script
             src="/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1?ray=abc">
             </script></body></html>"#;
+        assert!(is_bot_protected(html, &empty_headers()));
+    }
+
+    #[test]
+    fn is_bot_protected_ignores_hashed_cloudflare_jsd_beacon() {
+        // Cloudflare also serves the benign beacon under the `h/{b,g}` prefix
+        // with a hash segment. This form is why matching `challenge-platform`
+        // — or even `challenge-platform/h/` — is not a valid discriminator.
+        let html = r#"<html><head><script
+            src="/cdn-cgi/challenge-platform/h/g/scripts/jsd/e4025c85ea63/main.js">
+            </script></head><body>a perfectly ordinary page</body></html>"#;
+        assert!(!is_bot_protected(html, &empty_headers()));
+    }
+
+    #[test]
+    fn is_bot_protected_detects_full_interstitial() {
+        // Pins the false-negative property the narrowing is riskiest for: a
+        // complete managed-challenge page must still be caught.
+        let html = r#"<html><head><script>window._cf_chl_opt={cvId:'3'};</script>
+            <script src="/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1?ray=9a1">
+            </script></head><body>Just a moment...</body></html>"#;
         assert!(is_bot_protected(html, &empty_headers()));
     }
 

--- a/crates/webclaw-fetch/src/cloud.rs
+++ b/crates/webclaw-fetch/src/cloud.rs
@@ -400,19 +400,21 @@ pub fn is_bot_protected(html: &str, headers: &HeaderMap) -> bool {
     // the real interstitial loads
     // `/cdn-cgi/challenge-platform/h/{b,g}/orchestrate/chl_page/v1?ray=…`.
     //
-    // BOTH halves of that path are required. Cloudflare injects a benign
-    // JS-detection beacon into ordinary 200 responses under both
-    // `/cdn-cgi/challenge-platform/scripts/jsd/main.js` and the hashed
-    // `/cdn-cgi/challenge-platform/h/g/scripts/jsd/<hash>/main.js`, so
-    // `challenge-platform` (and `challenge-platform/h/`) match healthy pages.
-    // But `/orchestrate/` alone is no good either: it is an ordinary word in
-    // API paths, so a docs site with a nav link to `/guides/orchestrate/`
-    // would be flagged as challenged. Requiring the `cdn-cgi` prefix as well
-    // pins it to Cloudflare's own path namespace.
-    let cf_challenge_platform = html_lower.contains("/cdn-cgi/challenge-platform/");
-    if html_lower.contains("_cf_chl_opt")
-        || (cf_challenge_platform && html_lower.contains("/orchestrate/"))
-    {
+    // `orchestrate/chl_page` is the whole discriminator, and it has to be
+    // this specific. Each looser form flags healthy pages:
+    //   - `challenge-platform` and `challenge-platform/h/` both match the
+    //     benign JS-detection beacon Cloudflare injects into ordinary 200
+    //     responses, served under `/cdn-cgi/challenge-platform/scripts/jsd/
+    //     main.js` AND `/cdn-cgi/challenge-platform/h/g/scripts/jsd/<hash>/
+    //     main.js`.
+    //   - `/orchestrate/` alone is an ordinary word in API paths — real pages
+    //     on github.com, pypi.org and IBM's watsonx docs all contain it.
+    //   - even `/cdn-cgi/challenge-platform/` AND `/orchestrate/` as separate
+    //     substrings co-occur on a Cloudflare-fronted docs site that links to
+    //     `/docs/orchestrate/…`, which is exactly what a workflow-tool site
+    //     looks like.
+    // One contiguous literal avoids all three.
+    if html_lower.contains("_cf_chl_opt") || html_lower.contains("orchestrate/chl_page") {
         return true;
     }
 
@@ -710,10 +712,23 @@ mod tests {
 
     #[test]
     fn is_bot_protected_ignores_orchestrate_outside_cloudflare_path() {
-        // "orchestrate" is an ordinary word in API/doc paths. Matching it
-        // unanchored would flag any workflow-orchestration docs page.
+        // "orchestrate" is an ordinary word in API/doc paths — verified live
+        // on github.com, pypi.org and IBM's watsonx docs. Matching it
+        // unanchored flagged all of them as challenges.
         let html = r#"<html><body><nav><a href="/guides/orchestrate/">Orchestrate</a>
             <a href="/docs/orchestrate/schedules">Schedules</a></nav>
+            <h1>Orchestrate your pipelines</h1></body></html>"#;
+        assert!(!is_bot_protected(html, &empty_headers()));
+    }
+
+    #[test]
+    fn is_bot_protected_ignores_orchestrate_link_on_cloudflare_fronted_docs() {
+        // The hard case: a Cloudflare-fronted docs site carries the benign
+        // beacon AND links to `/docs/orchestrate/…`. Testing the two
+        // substrings separately would flag it; one contiguous literal does not.
+        let html = r#"<html><head><script
+            src="/cdn-cgi/challenge-platform/h/g/scripts/jsd/e4025c85ea63/main.js">
+            </script></head><body><a href="/docs/orchestrate/schedules">Schedules</a>
             <h1>Orchestrate your pipelines</h1></body></html>"#;
         assert!(!is_bot_protected(html, &empty_headers()));
     }

--- a/crates/webclaw-fetch/src/cloud.rs
+++ b/crates/webclaw-fetch/src/cloud.rs
@@ -397,19 +397,31 @@ pub fn is_bot_protected(html: &str, headers: &HeaderMap) -> bool {
     let html_lower = html.to_lowercase();
 
     // Cloudflare challenge page. `_cf_chl_opt` is the challenge options blob;
-    // `/orchestrate/` is the script a real interstitial loads
-    // (`/cdn-cgi/challenge-platform/h/{b,g}/orchestrate/chl_page/v1?ray=…`).
+    // the real interstitial loads
+    // `/cdn-cgi/challenge-platform/h/{b,g}/orchestrate/chl_page/v1?ray=…`.
     //
-    // Matching any looser form of `challenge-platform` is wrong: Cloudflare
-    // injects a benign JS-detection beacon into ordinary 200 responses, and it
-    // is served under BOTH the short path
-    // (`/cdn-cgi/challenge-platform/scripts/jsd/main.js`) and the hashed one
-    // (`/cdn-cgi/challenge-platform/h/g/scripts/jsd/<hash>/main.js`). So
-    // neither `challenge-platform` nor `challenge-platform/h/` discriminates —
-    // both flag healthy pages and burn a cloud escalation on a challenge that
-    // was never there. `/orchestrate/` appears only on the real interstitial;
-    // the beacon always sits under `/scripts/`.
-    if html_lower.contains("_cf_chl_opt") || html_lower.contains("/orchestrate/") {
+    // BOTH halves of that path are required. Cloudflare injects a benign
+    // JS-detection beacon into ordinary 200 responses under both
+    // `/cdn-cgi/challenge-platform/scripts/jsd/main.js` and the hashed
+    // `/cdn-cgi/challenge-platform/h/g/scripts/jsd/<hash>/main.js`, so
+    // `challenge-platform` (and `challenge-platform/h/`) match healthy pages.
+    // But `/orchestrate/` alone is no good either: it is an ordinary word in
+    // API paths, so a docs site with a nav link to `/guides/orchestrate/`
+    // would be flagged as challenged. Requiring the `cdn-cgi` prefix as well
+    // pins it to Cloudflare's own path namespace.
+    let cf_challenge_platform = html_lower.contains("/cdn-cgi/challenge-platform/");
+    if html_lower.contains("_cf_chl_opt")
+        || (cf_challenge_platform && html_lower.contains("/orchestrate/"))
+    {
+        return true;
+    }
+
+    // `cf-mitigated` is set only when Cloudflare actually mitigated the
+    // request, so unlike `cf-ray` (present on every proxied response) it is
+    // conclusive on its own. Catches terminal block pages (1020 "Access
+    // denied" / "Sorry, you have been blocked"), which carry neither the
+    // challenge blob nor the orchestrate script.
+    if headers.get("cf-mitigated").is_some() {
         return true;
     }
 
@@ -694,6 +706,27 @@ mod tests {
             src="/cdn-cgi/challenge-platform/h/g/scripts/jsd/e4025c85ea63/main.js">
             </script></head><body>a perfectly ordinary page</body></html>"#;
         assert!(!is_bot_protected(html, &empty_headers()));
+    }
+
+    #[test]
+    fn is_bot_protected_ignores_orchestrate_outside_cloudflare_path() {
+        // "orchestrate" is an ordinary word in API/doc paths. Matching it
+        // unanchored would flag any workflow-orchestration docs page.
+        let html = r#"<html><body><nav><a href="/guides/orchestrate/">Orchestrate</a>
+            <a href="/docs/orchestrate/schedules">Schedules</a></nav>
+            <h1>Orchestrate your pipelines</h1></body></html>"#;
+        assert!(!is_bot_protected(html, &empty_headers()));
+    }
+
+    #[test]
+    fn is_bot_protected_detects_cf_mitigated_header() {
+        // Terminal block pages (1020) carry neither `_cf_chl_opt` nor the
+        // orchestrate script, but Cloudflare only sets `cf-mitigated` when it
+        // actually mitigated — so the header alone is conclusive.
+        let mut headers = HeaderMap::new();
+        headers.insert("cf-mitigated", "challenge".parse().expect("valid header"));
+        let html = "<html><body>Sorry, you have been blocked</body></html>";
+        assert!(is_bot_protected(html, &headers));
     }
 
     #[test]

--- a/crates/webclaw-fetch/src/extractors/chronopost.rs
+++ b/crates/webclaw-fetch/src/extractors/chronopost.rs
@@ -187,9 +187,13 @@ pub async fn extract(client: &dyn Fetcher, url: &str) -> Result<Value, FetchErro
         // so in prose, and it only renders `en` or `fr`, so match both. If
         // neither matches, the markup really has moved: keep that alarm loud
         // and distinct, because a routine bad number must not trip it.
+        // Matched on apostrophe-FREE fragments: the message contains one, and
+        // whether it arrives as `&#x27;`, `&rsquo;` or a literal U+2019 is a
+        // template detail. Anchoring around it keeps a routine bad number from
+        // re-tripping the markup-moved alarm on a typographic-quote change.
         let top_text = strip_tags(top).to_lowercase();
-        let unknown_parcel = top_text.contains("don't have any information")
-            || top_text.contains("n'avons pas d'information");
+        let unknown_parcel =
+            top_text.contains("have any information") || top_text.contains("avons pas d");
         return Err(if unknown_parcel {
             FetchError::Build(format!(
                 "chronopost: no tracking information for '{numbers}' — check the number"
@@ -258,9 +262,11 @@ fn parse_steps(top: &str) -> Vec<Step> {
             .expect("valid step-info regex")
     });
     let text_re = TEXT.get_or_init(|| {
-        // `\s*` not `[^"]*`: tolerates the trailing space Chronopost's
-        // templates emit without also matching `…-light-textual`.
-        Regex::new(r#"(?s)class="ch-suivi-colis-light-text\s*"[^>]*>(.*?)</div>"#)
+        // `(?:\s[^"]*)?` — the name must end at the quote or at whitespace,
+        // which rejects `…-light-textual` while still tolerating both the
+        // trailing space Chronopost emits and any additional modifier class.
+        // Non-capturing so group 1 stays the label.
+        Regex::new(r#"(?s)class="ch-suivi-colis-light-text(?:\s[^"]*)?"[^>]*>(.*?)</div>"#)
             .expect("valid step-text regex")
     });
 
@@ -384,6 +390,13 @@ fn strip_tags(html: &str) -> String {
         .replace("&nbsp;", " ")
         .replace("&#x27;", "'")
         .replace("&#39;", "'")
+        // Typographic apostrophe, in all three spellings plus the literal
+        // char. French copy uses it freely and it shows up inside labels
+        // ("shipper's"), so fold it to ASCII rather than leaving a raw entity.
+        .replace("&rsquo;", "'")
+        .replace("&#8217;", "'")
+        .replace("&#x2019;", "'")
+        .replace('\u{2019}', "'")
         .replace("&quot;", "\"")
         .replace("&lt;", "<")
         .replace("&gt;", ">")
@@ -545,6 +558,34 @@ mod tests {
               <div class="ch-suivi-colis-light-textual">Not a step</div>
             </div>"#;
         assert!(parse_steps(top).is_empty());
+    }
+
+    #[test]
+    fn parse_steps_tolerates_a_modifier_class_on_the_label() {
+        // Tightening the text class to `\s*` required it to be the ONLY
+        // class, silently dropping a step whose label carried a modifier.
+        let top = r#"<div class="ch-suivi-colis-light-info active ">
+              <div class="ch-suivi-colis-light-text bold">Delivered</div>
+            </div>"#;
+        let steps = parse_steps(top);
+        assert_eq!(steps.len(), 1, "a modifier class must not drop the step");
+        assert_eq!(steps[0].label, "Delivered");
+        assert_eq!(steps[0].state, "current");
+    }
+
+    #[test]
+    fn strip_tags_folds_typographic_apostrophes() {
+        // The unknown-parcel prose match and the milestone labels both depend
+        // on this; French copy uses U+2019 freely.
+        for raw in [
+            "shipper&#x27;s",
+            "shipper&rsquo;s",
+            "shipper&#8217;s",
+            "shipper&#x2019;s",
+            "shipper\u{2019}s",
+        ] {
+            assert_eq!(strip_tags(raw), "shipper's", "failed for {raw}");
+        }
     }
 
     #[test]

--- a/crates/webclaw-fetch/src/extractors/chronopost.rs
+++ b/crates/webclaw-fetch/src/extractors/chronopost.rs
@@ -1,0 +1,412 @@
+//! Chronopost parcel-tracking structured extractor.
+//!
+//! The public tracking page (`/tracking-no-cms/suivi-page?listeNumerosLT=…`)
+//! is an empty jQuery shell: `resources/js/trackinginfos.js` GETs
+//! `/tracking-no-cms/suivi-colis` and injects the response, so fetching the
+//! page itself yields a 200 with zero extractable words.
+//!
+//! That AJAX endpoint only answers with real data when the request carries
+//! `X-Requested-With: XMLHttpRequest`. Without it Chronopost serves a
+//! "Site en maintenance" page — a decoy that reads like a genuine outage and
+//! will send you looking for a problem that isn't there.
+//!
+//! The endpoint returns JSON whose fields hold HTML fragments. Two matter:
+//! - `top` — the milestone progress bar, one `<div id="stepN">` per
+//!   milestone whose class carries the state (`before` = done, `active` =
+//!   current, `after` = pending).
+//! - `tab` — the scan-event table, one `<tr>` per event with `<br />`
+//!   separating date/time and office/event-label.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde_json::{Value, json};
+
+use super::ExtractorInfo;
+use crate::error::FetchError;
+use crate::fetcher::Fetcher;
+
+pub const INFO: ExtractorInfo = ExtractorInfo {
+    name: "chronopost",
+    label: "Chronopost tracking",
+    description: "Returns parcel tracking: current status, milestone progress, and the full scan-event history.",
+    url_patterns: &["https://www.chronopost.fr/tracking-no-cms/suivi-page?listeNumerosLT={number}"],
+};
+
+/// Host suffix check — Chronopost runs country sites but the tracking app
+/// lives on the `.fr` domain, which is where the AJAX endpoint is rooted.
+fn host_of(url: &str) -> &str {
+    url.split("://")
+        .nth(1)
+        .unwrap_or(url)
+        .split('/')
+        .next()
+        .unwrap_or("")
+        .split('@')
+        .next_back()
+        .unwrap_or("")
+}
+
+pub fn matches(url: &str) -> bool {
+    let host = host_of(url).to_ascii_lowercase();
+    let host = host.split(':').next().unwrap_or("");
+    if host != "chronopost.fr" && host != "www.chronopost.fr" {
+        return false;
+    }
+    // The tracking number is the whole point — a bare /tracking-no-cms/ path
+    // has nothing to extract.
+    query_param(url, "listeNumerosLT").is_some_and(|v| !v.is_empty())
+}
+
+/// Pull a query parameter without pulling in a full URL parse for what is
+/// always a flat `?a=b&c=d` string. Returns the percent-decoded value.
+fn query_param(url: &str, key: &str) -> Option<String> {
+    let query = url.split_once('?')?.1;
+    let query = query.split('#').next().unwrap_or("");
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k == key).then(|| percent_decode(v))
+    })
+}
+
+/// Minimal percent-decoder. Tracking numbers are alphanumeric and `langue`
+/// is a two-letter code, so this only has to survive the occasional `%2C`
+/// between numbers in a multi-parcel query.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let Ok(b) = u8::from_str_radix(&s[i + 1..i + 3], 16)
+        {
+            out.push(b);
+            i += 3;
+            continue;
+        }
+        out.push(if bytes[i] == b'+' { b' ' } else { bytes[i] });
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+pub async fn extract(client: &dyn Fetcher, url: &str) -> Result<Value, FetchError> {
+    let numbers = query_param(url, "listeNumerosLT")
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            FetchError::Build(format!(
+                "chronopost: no 'listeNumerosLT' tracking number in '{url}'"
+            ))
+        })?;
+    // Chronopost accepts `en`/`fr`; anything else renders French. Default to
+    // the caller's choice when present so labels come back in their language.
+    let langue = query_param(url, "langue").unwrap_or_else(|| "en".to_string());
+
+    let api_url = format!(
+        "https://www.chronopost.fr/tracking-no-cms/suivi-colis?listeNumerosLT={numbers}&langue={langue}"
+    );
+    // `X-Requested-With` is load-bearing: without it the endpoint returns a
+    // "Site en maintenance" HTML page instead of the tracking JSON. The
+    // Referer mirrors what the real page sends.
+    let resp = client
+        .fetch_with_headers(
+            &api_url,
+            &[
+                ("X-Requested-With", "XMLHttpRequest"),
+                ("Referer", url),
+                ("Accept", "text/html, */*; q=0.01"),
+            ],
+        )
+        .await?;
+
+    if resp.status != 200 {
+        return Err(FetchError::Build(format!(
+            "chronopost: tracking endpoint returned status {}",
+            resp.status
+        )));
+    }
+
+    let body = resp.html.trim_start();
+    if body.starts_with('<') {
+        // The maintenance decoy (or any other HTML) came back — almost always
+        // means the AJAX header was dropped somewhere in the fetch path.
+        return Err(FetchError::BodyDecode(
+            "chronopost: endpoint returned HTML, not tracking JSON \
+             (the 'Site en maintenance' decoy served when \
+             'X-Requested-With: XMLHttpRequest' is missing)"
+                .to_string(),
+        ));
+    }
+
+    let payload: Value = serde_json::from_str(body)
+        .map_err(|e| FetchError::BodyDecode(format!("chronopost: parse tracking JSON: {e}")))?;
+
+    if let Some(err) = payload.get("error").and_then(Value::as_str)
+        && !err.trim().is_empty()
+    {
+        return Err(FetchError::Build(format!(
+            "chronopost: {}",
+            strip_tags(err)
+        )));
+    }
+
+    let top = payload.get("top").and_then(Value::as_str).unwrap_or("");
+    let tab = payload.get("tab").and_then(Value::as_str).unwrap_or("");
+
+    let steps = parse_steps(top);
+    let status = steps
+        .iter()
+        .find(|s| s.state == "current")
+        .map(|s| s.label.clone());
+    let events = parse_events(tab);
+
+    Ok(json!({
+        "tracking_number": numbers,
+        "language": langue,
+        "status": status,
+        "steps": steps
+            .iter()
+            .map(|s| json!({ "label": s.label, "state": s.state }))
+            .collect::<Vec<_>>(),
+        "events": events
+            .iter()
+            .map(|e| json!({
+                "date": e.date,
+                "time": e.time,
+                "office": e.office,
+                "event": e.event,
+                "details": e.details,
+            }))
+            .collect::<Vec<_>>(),
+        "event_count": events.len(),
+        "source_url": url,
+    }))
+}
+
+// -- parsing -----------------------------------------------------------------
+
+#[derive(Debug, PartialEq)]
+struct Step {
+    label: String,
+    state: &'static str,
+}
+
+/// Parse the milestone progress bar out of the `top` fragment.
+///
+/// Chronopost renders the bar twice (desktop + mobile variants share the
+/// same `id`s), so identical labels are de-duplicated, keeping first-seen
+/// order.
+fn parse_steps(top: &str) -> Vec<Step> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(
+            r#"(?s)<div[^>]*class="ch-suivi-colis-light-info([^"]*)".*?ch-suivi-colis-light-text"[^>]*>(.*?)</div>"#,
+        )
+        .expect("valid step regex")
+    });
+
+    let mut out: Vec<Step> = Vec::new();
+    for cap in re.captures_iter(top) {
+        let classes = cap.get(1).map_or("", |m| m.as_str());
+        let label = strip_tags(cap.get(2).map_or("", |m| m.as_str()));
+        if label.is_empty() {
+            continue;
+        }
+        // `active` before `after`: the current step's class list is
+        // `ch-suivi-colis-light-info active`, pending ones carry `after`.
+        let state = if classes.contains("active") {
+            "current"
+        } else if classes.contains("after") {
+            "pending"
+        } else {
+            "completed"
+        };
+        if !out.iter().any(|s| s.label == label) {
+            out.push(Step { label, state });
+        }
+    }
+    out
+}
+
+#[derive(Debug, PartialEq)]
+struct Event {
+    date: String,
+    time: String,
+    office: String,
+    event: String,
+    details: String,
+}
+
+/// Parse the scan-event table out of the `tab` fragment.
+///
+/// Each `<tr>` holds three cells: date/time, office/event label, and free-form
+/// details — the first two split on `<br />`.
+fn parse_events(tab: &str) -> Vec<Event> {
+    static ROW: OnceLock<Regex> = OnceLock::new();
+    static CELL: OnceLock<Regex> = OnceLock::new();
+    let row_re =
+        ROW.get_or_init(|| Regex::new(r"(?s)<tr[^>]*>(.*?)</tr>").expect("valid row regex"));
+    let cell_re = CELL
+        .get_or_init(|| Regex::new(r"(?s)<t[dh][^>]*>(.*?)</t[dh]>").expect("valid cell regex"));
+
+    let mut out = Vec::new();
+    for row in row_re.captures_iter(tab) {
+        let inner = row.get(1).map_or("", |m| m.as_str());
+        let cells: Vec<&str> = cell_re
+            .captures_iter(inner)
+            .filter_map(|c| c.get(1).map(|m| m.as_str()))
+            .collect();
+        if cells.len() < 2 {
+            continue;
+        }
+        let (date, time) = split_br(cells[0]);
+        let (office, event) = split_br(cells[1]);
+        let details = cells.get(2).map(|c| strip_tags(c)).unwrap_or_default();
+        // The header row has no date and no <br /> split — skip it.
+        if date.is_empty() || time.is_empty() {
+            continue;
+        }
+        out.push(Event {
+            date,
+            time,
+            office,
+            event,
+            details,
+        });
+    }
+    out
+}
+
+/// Split a cell on its `<br />` into (first, rest). A cell without a break
+/// puts everything in the first slot.
+fn split_br(cell: &str) -> (String, String) {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| Regex::new(r"(?i)<br\s*/?>").expect("valid br regex"));
+    let mut parts = re.splitn(cell, 2);
+    let first = strip_tags(parts.next().unwrap_or(""));
+    let rest = parts.next().map(strip_tags).unwrap_or_default();
+    (first, rest)
+}
+
+/// Drop tags, decode the entities Chronopost actually emits, and collapse the
+/// tab/newline runs its templates leave behind.
+fn strip_tags(html: &str) -> String {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| Regex::new(r"(?s)<[^>]+>").expect("valid tag regex"));
+    let text = re.replace_all(html, " ");
+    let decoded = text
+        .replace("&nbsp;", " ")
+        .replace("&#x27;", "'")
+        .replace("&#39;", "'")
+        .replace("&quot;", "\"")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        // `&amp;` last so a double-encoded `&amp;lt;` doesn't become a tag.
+        .replace("&amp;", "&");
+    decoded.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_tracking_urls() {
+        assert!(matches(
+            "https://www.chronopost.fr/tracking-no-cms/suivi-page?listeNumerosLT=XU171986142JF&langue=en"
+        ));
+        assert!(matches(
+            "https://chronopost.fr/tracking-no-cms/suivi-page?langue=fr&listeNumerosLT=XU171986142JF"
+        ));
+        // No tracking number => nothing to extract.
+        assert!(!matches(
+            "https://www.chronopost.fr/tracking-no-cms/suivi-page"
+        ));
+        assert!(!matches(
+            "https://www.chronopost.fr/tracking-no-cms/suivi-page?listeNumerosLT="
+        ));
+        assert!(!matches("https://www.chronopost.fr/en"));
+        // Host must not be spoofable by a lookalike or a userinfo prefix.
+        assert!(!matches(
+            "https://www.chronopost.fr.evil.com/x?listeNumerosLT=A1"
+        ));
+        assert!(!matches("https://user@evil.com/x?listeNumerosLT=A1"));
+    }
+
+    #[test]
+    fn query_param_reads_values_and_decodes() {
+        let url = "https://www.chronopost.fr/t?listeNumerosLT=AB1%2CCD2&langue=fr#frag";
+        assert_eq!(
+            query_param(url, "listeNumerosLT").as_deref(),
+            Some("AB1,CD2")
+        );
+        assert_eq!(query_param(url, "langue").as_deref(), Some("fr"));
+        assert_eq!(query_param(url, "missing"), None);
+        assert_eq!(query_param("https://x.fr/no-query", "langue"), None);
+    }
+
+    #[test]
+    fn parse_steps_marks_current_and_dedupes_variants() {
+        // Shape lifted from the live `top` fragment, including the duplicated
+        // desktop/mobile render.
+        let top = r#"
+            <div id="step1" class="ch-suivi-colis-light-info first before ">
+              <div class="ch-suivi-colis-light-picto "></div>
+              <div class="ch-suivi-colis-light-text">Under preparation at the shipper&#x27;s</div>
+            </div>
+            <div id="step5" class="ch-suivi-colis-light-info active ">
+              <div class="ch-suivi-colis-light-picto"></div>
+              <div class="ch-suivi-colis-light-text"> Delayed parcel </div>
+            </div>
+            <div id="step7" class="ch-suivi-colis-light-info after ">
+              <div class="ch-suivi-colis-light-picto "></div>
+              <div class="ch-suivi-colis-light-text">Out for delivery</div>
+            </div>
+            <div id="step5" class="ch-suivi-colis-light-info active ">
+              <div class="ch-suivi-colis-light-picto"></div>
+              <div class="ch-suivi-colis-light-text"> Delayed parcel </div>
+            </div>"#;
+        let steps = parse_steps(top);
+        assert_eq!(steps.len(), 3, "duplicate mobile variant must be deduped");
+        assert_eq!(steps[0].label, "Under preparation at the shipper's");
+        assert_eq!(steps[0].state, "completed");
+        assert_eq!(steps[1].label, "Delayed parcel");
+        assert_eq!(steps[1].state, "current");
+        assert_eq!(steps[2].state, "pending");
+    }
+
+    #[test]
+    fn parse_events_splits_cells_and_skips_header() {
+        // Real row shape, tabs and all.
+        let tab = r#"<table><tr><th>Date and time</th><th>The steps of my delivery</th>
+            <th>Supplement</th></tr>
+            <tr class="toggleElmt">	<td>Wednesday 07/29/2026<br />08:39 AM</td>
+            <td>CHRONOPOST NETWORKS<br />Parcel in transit</td>
+            <td colspan="2">	Scan location : Vijfhuizen - NL (depot 0516)	<br />	</td></tr>
+            <tr class="toggleElmt"><td>Friday 07/24/2026<br />03:49 PM</td>
+            <td>Web Services<br />Shipment in preparation</td>
+            <td colspan="2">Partner number : GEO/042&amp;33</td></tr></table>"#;
+        let events = parse_events(tab);
+        assert_eq!(events.len(), 2, "header row must be skipped");
+        assert_eq!(events[0].date, "Wednesday 07/29/2026");
+        assert_eq!(events[0].time, "08:39 AM");
+        assert_eq!(events[0].office, "CHRONOPOST NETWORKS");
+        assert_eq!(events[0].event, "Parcel in transit");
+        assert_eq!(
+            events[0].details,
+            "Scan location : Vijfhuizen - NL (depot 0516)"
+        );
+        assert_eq!(events[1].details, "Partner number : GEO/042&33");
+    }
+
+    #[test]
+    fn strip_tags_decodes_entities_and_collapses_whitespace() {
+        assert_eq!(
+            strip_tags("<td>\t\tUnder preparation at the shipper&#x27;s\n</td>"),
+            "Under preparation at the shipper's"
+        );
+        assert_eq!(strip_tags("a&nbsp;&nbsp;b"), "a b");
+        assert_eq!(strip_tags("x &amp; y &gt; z"), "x & y > z");
+    }
+}

--- a/crates/webclaw-fetch/src/extractors/chronopost.rs
+++ b/crates/webclaw-fetch/src/extractors/chronopost.rs
@@ -37,6 +37,17 @@ pub fn matches(url: &str) -> bool {
     parse_tracking(url).is_some()
 }
 
+/// What a tracking URL yields once validated.
+struct Tracking {
+    /// `listeNumerosLT`, percent-decoded. May be a comma-separated list.
+    numbers: String,
+    /// `langue`, defaulting to `en`.
+    langue: String,
+    /// The caller's URL with any credentials removed, safe to echo back as
+    /// a `Referer` header.
+    referer: String,
+}
+
 /// Parse a tracking URL into `(tracking numbers, language)`.
 ///
 /// Returns `None` unless the host is exactly `chronopost.fr` /
@@ -51,8 +62,11 @@ pub fn matches(url: &str) -> bool {
 /// a `%` is followed by a multi-byte char. `Url` also normalises case,
 /// punycodes IDN, strips userinfo and port from `host_str`, and decodes
 /// query values without ever slicing off a char boundary.
-fn parse_tracking(url: &str) -> Option<(String, String)> {
+fn parse_tracking(url: &str) -> Option<Tracking> {
     let parsed = url::Url::parse(url).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
     let host = parsed.host_str()?.to_ascii_lowercase();
     if host != "chronopost.fr" && host != "www.chronopost.fr" {
         return None;
@@ -67,13 +81,29 @@ fn parse_tracking(url: &str) -> Option<(String, String)> {
             _ => {}
         }
     }
-    // Chronopost accepts `en`/`fr`; anything else renders French. Default to
-    // English so labels are readable when the caller didn't ask.
-    Some((numbers?, langue.unwrap_or_else(|| "en".to_string())))
+
+    // `https://user:pw@www.chronopost.fr/?...` is a legitimate URL, but the
+    // raw input is echoed back as `Referer` — so drop the credentials rather
+    // than forwarding them to Chronopost.
+    let mut referer = parsed.clone();
+    let _ = referer.set_username("");
+    let _ = referer.set_password(None);
+
+    Some(Tracking {
+        numbers: numbers?,
+        // Chronopost accepts `en`/`fr`; anything else renders French. Default
+        // to English so labels are readable when the caller didn't ask.
+        langue: langue.unwrap_or_else(|| "en".to_string()),
+        referer: referer.to_string(),
+    })
 }
 
 pub async fn extract(client: &dyn Fetcher, url: &str) -> Result<Value, FetchError> {
-    let (numbers, langue) = parse_tracking(url).ok_or_else(|| {
+    let Tracking {
+        numbers,
+        langue,
+        referer,
+    } = parse_tracking(url).ok_or_else(|| {
         FetchError::Build(format!(
             "chronopost: no 'listeNumerosLT' tracking number in '{url}'"
         ))
@@ -96,7 +126,7 @@ pub async fn extract(client: &dyn Fetcher, url: &str) -> Result<Value, FetchErro
             &api_url,
             &[
                 ("X-Requested-With", "XMLHttpRequest"),
-                ("Referer", url),
+                ("Referer", referer.as_str()),
                 ("Accept", "text/html, */*; q=0.01"),
             ],
         )
@@ -150,11 +180,27 @@ pub async fn extract(client: &dyn Fetcher, url: &str) -> Result<Value, FetchErro
     // parcel with no history, and (via `dispatch_by_url`) would stop the
     // caller from falling back to the generic scrape path.
     if steps.is_empty() && events.is_empty() {
-        return Err(FetchError::BodyDecode(
-            "chronopost: tracking response contained neither milestones nor \
-             scan events — the page markup has likely changed"
-                .to_string(),
-        ));
+        // Distinguish "this number has no data" from "our selectors broke".
+        // Both produce an empty parse, and structure can't tell them apart —
+        // the `ch-colis-information` block wraps the not-found message in the
+        // empty case AND the summary in the normal one. Chronopost does say
+        // so in prose, and it only renders `en` or `fr`, so match both. If
+        // neither matches, the markup really has moved: keep that alarm loud
+        // and distinct, because a routine bad number must not trip it.
+        let top_text = strip_tags(top).to_lowercase();
+        let unknown_parcel = top_text.contains("don't have any information")
+            || top_text.contains("n'avons pas d'information");
+        return Err(if unknown_parcel {
+            FetchError::Build(format!(
+                "chronopost: no tracking information for '{numbers}' — check the number"
+            ))
+        } else {
+            FetchError::BodyDecode(
+                "chronopost: tracking response contained neither milestones nor \
+                 scan events — the page markup has likely changed"
+                    .to_string(),
+            )
+        });
     }
 
     Ok(json!({
@@ -206,11 +252,15 @@ fn parse_steps(top: &str) -> Vec<Step> {
     static INFO: OnceLock<Regex> = OnceLock::new();
     static TEXT: OnceLock<Regex> = OnceLock::new();
     let info_re = INFO.get_or_init(|| {
-        Regex::new(r#"<div[^>]*class="ch-suivi-colis-light-info([^"]*)"[^>]*>"#)
+        // `(?:\s[^"]*)?` — the class name must end at the quote or at
+        // whitespace, so this can't also claim `…-light-infobox`.
+        Regex::new(r#"<div[^>]*class="ch-suivi-colis-light-info(\s[^"]*)?"[^>]*>"#)
             .expect("valid step-info regex")
     });
     let text_re = TEXT.get_or_init(|| {
-        Regex::new(r#"(?s)class="ch-suivi-colis-light-text[^"]*"[^>]*>(.*?)</div>"#)
+        // `\s*` not `[^"]*`: tolerates the trailing space Chronopost's
+        // templates emit without also matching `…-light-textual`.
+        Regex::new(r#"(?s)class="ch-suivi-colis-light-text\s*"[^>]*>(.*?)</div>"#)
             .expect("valid step-text regex")
     });
 
@@ -220,7 +270,11 @@ fn parse_steps(top: &str) -> Vec<Step> {
         .captures_iter(top)
         .filter_map(|c| {
             let whole = c.get(0)?;
-            Some((c.get(1)?.as_str(), whole.end(), whole.start()))
+            // Group 1 is optional — a milestone whose class list is exactly
+            // `ch-suivi-colis-light-info` has no trailing classes and must
+            // still count (it just has no state keyword, i.e. "completed").
+            let classes = c.get(1).map_or("", |m| m.as_str());
+            Some((classes, whole.end(), whole.start()))
         })
         .collect();
 
@@ -381,16 +435,37 @@ mod tests {
 
     #[test]
     fn parse_tracking_decodes_and_defaults_language() {
-        assert_eq!(
-            parse_tracking("https://www.chronopost.fr/t?listeNumerosLT=AB1%2CCD2&langue=fr#frag"),
-            Some(("AB1,CD2".to_string(), "fr".to_string()))
-        );
+        let t =
+            parse_tracking("https://www.chronopost.fr/t?listeNumerosLT=AB1%2CCD2&langue=fr#frag")
+                .expect("should parse");
+        assert_eq!(t.numbers, "AB1,CD2");
+        assert_eq!(t.langue, "fr");
+
         // `langue` absent => English default.
-        assert_eq!(
-            parse_tracking("https://www.chronopost.fr/t?listeNumerosLT=AB1"),
-            Some(("AB1".to_string(), "en".to_string()))
+        let t = parse_tracking("https://www.chronopost.fr/t?listeNumerosLT=AB1").expect("parses");
+        assert_eq!(t.langue, "en");
+
+        assert!(parse_tracking("https://www.chronopost.fr/no-query").is_none());
+    }
+
+    #[test]
+    fn parse_tracking_strips_credentials_from_referer() {
+        // The caller's URL is echoed back as `Referer`; credentials in it
+        // must not be forwarded to Chronopost.
+        let t = parse_tracking("https://user:hunter2@www.chronopost.fr/t?listeNumerosLT=AB1")
+            .expect("credentials are legal in a URL, so this still parses");
+        assert!(
+            !t.referer.contains("hunter2") && !t.referer.contains("user"),
+            "referer must not carry credentials, got {}",
+            t.referer
         );
-        assert_eq!(parse_tracking("https://www.chronopost.fr/no-query"), None);
+    }
+
+    #[test]
+    fn parse_tracking_rejects_non_http_schemes() {
+        assert!(parse_tracking("ftp://www.chronopost.fr/?listeNumerosLT=A1").is_none());
+        assert!(parse_tracking("wacky://www.chronopost.fr/?listeNumerosLT=A1").is_none());
+        assert!(parse_tracking("http://www.chronopost.fr/?listeNumerosLT=A1").is_some());
     }
 
     #[test]
@@ -460,6 +535,27 @@ mod tests {
             steps[0].state, "current",
             "label must keep its OWN step's state, not the previous step's"
         );
+    }
+
+    #[test]
+    fn parse_steps_ignores_classes_that_merely_share_a_prefix() {
+        // `[^"]*` after the class name also matched `…-light-infobox` and
+        // `…-light-textual`, inventing a step out of unrelated markup.
+        let top = r#"<div class="ch-suivi-colis-light-infobox foo">
+              <div class="ch-suivi-colis-light-textual">Not a step</div>
+            </div>"#;
+        assert!(parse_steps(top).is_empty());
+    }
+
+    #[test]
+    fn parse_steps_keeps_a_step_with_no_extra_classes() {
+        // The state keyword is optional; a bare class list means "completed".
+        let top = r#"<div class="ch-suivi-colis-light-info">
+              <div class="ch-suivi-colis-light-text">Taken up</div>
+            </div>"#;
+        let steps = parse_steps(top);
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].state, "completed");
     }
 
     #[test]

--- a/crates/webclaw-fetch/src/extractors/chronopost.rs
+++ b/crates/webclaw-fetch/src/extractors/chronopost.rs
@@ -33,79 +33,61 @@ pub const INFO: ExtractorInfo = ExtractorInfo {
     url_patterns: &["https://www.chronopost.fr/tracking-no-cms/suivi-page?listeNumerosLT={number}"],
 };
 
-/// Host suffix check — Chronopost runs country sites but the tracking app
-/// lives on the `.fr` domain, which is where the AJAX endpoint is rooted.
-fn host_of(url: &str) -> &str {
-    url.split("://")
-        .nth(1)
-        .unwrap_or(url)
-        .split('/')
-        .next()
-        .unwrap_or("")
-        .split('@')
-        .next_back()
-        .unwrap_or("")
-}
-
 pub fn matches(url: &str) -> bool {
-    let host = host_of(url).to_ascii_lowercase();
-    let host = host.split(':').next().unwrap_or("");
+    parse_tracking(url).is_some()
+}
+
+/// Parse a tracking URL into `(tracking numbers, language)`.
+///
+/// Returns `None` unless the host is exactly `chronopost.fr` /
+/// `www.chronopost.fr` and a non-empty `listeNumerosLT` is present — the
+/// tracking number is the whole point, and this predicate gates
+/// `dispatch_by_url` auto-detect, so it must not claim a URL it can't serve.
+///
+/// Uses `Url` rather than hand-rolled string splitting. That is not just
+/// tidiness: splitting on `://`, `/`, then `@` reads the host out of the
+/// *query* on a URL with no path (`https://evil.com?x&@www.chronopost.fr`),
+/// and a hand-rolled percent-decoder that slices `&s[i+1..i+3]` panics when
+/// a `%` is followed by a multi-byte char. `Url` also normalises case,
+/// punycodes IDN, strips userinfo and port from `host_str`, and decodes
+/// query values without ever slicing off a char boundary.
+fn parse_tracking(url: &str) -> Option<(String, String)> {
+    let parsed = url::Url::parse(url).ok()?;
+    let host = parsed.host_str()?.to_ascii_lowercase();
     if host != "chronopost.fr" && host != "www.chronopost.fr" {
-        return false;
+        return None;
     }
-    // The tracking number is the whole point — a bare /tracking-no-cms/ path
-    // has nothing to extract.
-    query_param(url, "listeNumerosLT").is_some_and(|v| !v.is_empty())
-}
 
-/// Pull a query parameter without pulling in a full URL parse for what is
-/// always a flat `?a=b&c=d` string. Returns the percent-decoded value.
-fn query_param(url: &str, key: &str) -> Option<String> {
-    let query = url.split_once('?')?.1;
-    let query = query.split('#').next().unwrap_or("");
-    query.split('&').find_map(|pair| {
-        let (k, v) = pair.split_once('=')?;
-        (k == key).then(|| percent_decode(v))
-    })
-}
-
-/// Minimal percent-decoder. Tracking numbers are alphanumeric and `langue`
-/// is a two-letter code, so this only has to survive the occasional `%2C`
-/// between numbers in a multi-parcel query.
-fn percent_decode(s: &str) -> String {
-    let bytes = s.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%'
-            && i + 2 < bytes.len()
-            && let Ok(b) = u8::from_str_radix(&s[i + 1..i + 3], 16)
-        {
-            out.push(b);
-            i += 3;
-            continue;
+    let mut numbers = None;
+    let mut langue = None;
+    for (k, v) in parsed.query_pairs() {
+        match k.as_ref() {
+            "listeNumerosLT" if !v.is_empty() => numbers = Some(v.into_owned()),
+            "langue" if !v.is_empty() => langue = Some(v.into_owned()),
+            _ => {}
         }
-        out.push(if bytes[i] == b'+' { b' ' } else { bytes[i] });
-        i += 1;
     }
-    String::from_utf8_lossy(&out).into_owned()
+    // Chronopost accepts `en`/`fr`; anything else renders French. Default to
+    // English so labels are readable when the caller didn't ask.
+    Some((numbers?, langue.unwrap_or_else(|| "en".to_string())))
 }
 
 pub async fn extract(client: &dyn Fetcher, url: &str) -> Result<Value, FetchError> {
-    let numbers = query_param(url, "listeNumerosLT")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            FetchError::Build(format!(
-                "chronopost: no 'listeNumerosLT' tracking number in '{url}'"
-            ))
-        })?;
-    // Chronopost accepts `en`/`fr`; anything else renders French. Default to
-    // the caller's choice when present so labels come back in their language.
-    let langue = query_param(url, "langue").unwrap_or_else(|| "en".to_string());
+    let (numbers, langue) = parse_tracking(url).ok_or_else(|| {
+        FetchError::Build(format!(
+            "chronopost: no 'listeNumerosLT' tracking number in '{url}'"
+        ))
+    })?;
 
-    let api_url = format!(
-        "https://www.chronopost.fr/tracking-no-cms/suivi-colis?listeNumerosLT={numbers}&langue={langue}"
-    );
+    // Built through `query_pairs_mut` rather than `format!`: the values come
+    // back percent-DECODED, so interpolating them raw would let a number like
+    // `X%26langue%3Dfr` inject an extra parameter into our own request.
+    let mut api = url::Url::parse("https://www.chronopost.fr/tracking-no-cms/suivi-colis")
+        .expect("static URL is valid");
+    api.query_pairs_mut()
+        .append_pair("listeNumerosLT", &numbers)
+        .append_pair("langue", &langue);
+    let api_url = api.to_string();
     // `X-Requested-With` is load-bearing: without it the endpoint returns a
     // "Site en maintenance" HTML page instead of the tracking JSON. The
     // Referer mirrors what the real page sends.
@@ -161,6 +143,20 @@ pub async fn extract(client: &dyn Fetcher, url: &str) -> Result<Value, FetchErro
         .map(|s| s.label.clone());
     let events = parse_events(tab);
 
+    // Fail loudly rather than returning a well-formed empty result. The
+    // endpoint answered 200 with JSON, so if we recovered neither a milestone
+    // nor a scan event the markup has moved and our selectors are stale —
+    // reporting `Ok` with empty arrays would make a site redesign look like a
+    // parcel with no history, and (via `dispatch_by_url`) would stop the
+    // caller from falling back to the generic scrape path.
+    if steps.is_empty() && events.is_empty() {
+        return Err(FetchError::BodyDecode(
+            "chronopost: tracking response contained neither milestones nor \
+             scan events — the page markup has likely changed"
+                .to_string(),
+        ));
+    }
+
     Ok(json!({
         "tracking_number": numbers,
         "language": langue,
@@ -197,19 +193,54 @@ struct Step {
 /// Chronopost renders the bar twice (desktop + mobile variants share the
 /// same `id`s), so identical labels are de-duplicated, keeping first-seen
 /// order.
+///
+/// Each milestone is sliced out on its own boundary before the label is read,
+/// rather than matched with one pattern spanning both `<div>`s. A single
+/// spanning pattern bridges two milestones whenever one renders without a
+/// text child — it would pair step N's class list with step N+1's label,
+/// mis-assigning the state and silently swallowing a step. (`regex` has no
+/// lookaround, so the gap can't simply be told to stop at the next
+/// milestone.) `[^"]*` after each class name tolerates the trailing space
+/// Chronopost's templates emit, e.g. `class="ch-suivi-colis-light-text "`.
 fn parse_steps(top: &str) -> Vec<Step> {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| {
-        Regex::new(
-            r#"(?s)<div[^>]*class="ch-suivi-colis-light-info([^"]*)".*?ch-suivi-colis-light-text"[^>]*>(.*?)</div>"#,
-        )
-        .expect("valid step regex")
+    static INFO: OnceLock<Regex> = OnceLock::new();
+    static TEXT: OnceLock<Regex> = OnceLock::new();
+    let info_re = INFO.get_or_init(|| {
+        Regex::new(r#"<div[^>]*class="ch-suivi-colis-light-info([^"]*)"[^>]*>"#)
+            .expect("valid step-info regex")
+    });
+    let text_re = TEXT.get_or_init(|| {
+        Regex::new(r#"(?s)class="ch-suivi-colis-light-text[^"]*"[^>]*>(.*?)</div>"#)
+            .expect("valid step-text regex")
     });
 
+    // (class list, where this milestone's content starts, where its opening
+    // tag starts). Byte offsets from `regex` are always char boundaries.
+    let heads: Vec<(&str, usize, usize)> = info_re
+        .captures_iter(top)
+        .filter_map(|c| {
+            let whole = c.get(0)?;
+            Some((c.get(1)?.as_str(), whole.end(), whole.start()))
+        })
+        .collect();
+
     let mut out: Vec<Step> = Vec::new();
-    for cap in re.captures_iter(top) {
-        let classes = cap.get(1).map_or("", |m| m.as_str());
-        let label = strip_tags(cap.get(2).map_or("", |m| m.as_str()));
+    for (i, (classes, content_start, _)) in heads.iter().enumerate() {
+        // Stop at the next milestone's opening tag so a label can never be
+        // borrowed from the following step.
+        let stop = heads
+            .get(i + 1)
+            .map(|(_, _, next_start)| *next_start)
+            .unwrap_or(top.len());
+        if stop <= *content_start {
+            continue;
+        }
+        let Some(label) = text_re
+            .captures(&top[*content_start..stop])
+            .and_then(|c| c.get(1).map(|m| strip_tags(m.as_str())))
+        else {
+            continue;
+        };
         if label.is_empty() {
             continue;
         }
@@ -332,18 +363,52 @@ mod tests {
             "https://www.chronopost.fr.evil.com/x?listeNumerosLT=A1"
         ));
         assert!(!matches("https://user@evil.com/x?listeNumerosLT=A1"));
+        assert!(!matches(
+            "https://chronopost.fr@evil.com/x?listeNumerosLT=A1"
+        ));
+        // Regression: with no path segment there is no `/` to split on, so
+        // hand-rolled host parsing read the host out of the QUERY and matched.
+        assert!(!matches(
+            "https://evil.com?listeNumerosLT=A1&@www.chronopost.fr"
+        ));
+        assert!(!matches(
+            r"https://evil.com\@www.chronopost.fr/?listeNumerosLT=A1"
+        ));
+        // Not a URL at all must be rejected, not panic.
+        assert!(!matches("not a url"));
+        assert!(!matches(""));
     }
 
     #[test]
-    fn query_param_reads_values_and_decodes() {
-        let url = "https://www.chronopost.fr/t?listeNumerosLT=AB1%2CCD2&langue=fr#frag";
+    fn parse_tracking_decodes_and_defaults_language() {
         assert_eq!(
-            query_param(url, "listeNumerosLT").as_deref(),
-            Some("AB1,CD2")
+            parse_tracking("https://www.chronopost.fr/t?listeNumerosLT=AB1%2CCD2&langue=fr#frag"),
+            Some(("AB1,CD2".to_string(), "fr".to_string()))
         );
-        assert_eq!(query_param(url, "langue").as_deref(), Some("fr"));
-        assert_eq!(query_param(url, "missing"), None);
-        assert_eq!(query_param("https://x.fr/no-query", "langue"), None);
+        // `langue` absent => English default.
+        assert_eq!(
+            parse_tracking("https://www.chronopost.fr/t?listeNumerosLT=AB1"),
+            Some(("AB1".to_string(), "en".to_string()))
+        );
+        assert_eq!(parse_tracking("https://www.chronopost.fr/no-query"), None);
+    }
+
+    #[test]
+    fn parse_tracking_survives_malformed_percent_escapes() {
+        // Regression: a hand-rolled decoder sliced `&s[i+1..i+3]` on byte
+        // indices and panicked when a `%` was followed by a multi-byte char.
+        // This ran inside `matches()`, i.e. before any fetch, so it was
+        // reachable from every dispatch path.
+        for bad in [
+            "https://www.chronopost.fr/t?listeNumerosLT=%a\u{e9}",
+            "https://www.chronopost.fr/t?listeNumerosLT=%",
+            "https://www.chronopost.fr/t?listeNumerosLT=%zz",
+            "https://www.chronopost.fr/t?listeNumerosLT=\u{e9}%",
+        ] {
+            // Must not panic; value is whatever the URL parser makes of it.
+            let _ = matches(bad);
+            let _ = parse_tracking(bad);
+        }
     }
 
     #[test]
@@ -374,6 +439,40 @@ mod tests {
         assert_eq!(steps[1].label, "Delayed parcel");
         assert_eq!(steps[1].state, "current");
         assert_eq!(steps[2].state, "pending");
+    }
+
+    #[test]
+    fn parse_steps_does_not_bridge_a_step_with_no_label() {
+        // Regression: one pattern spanning both <div>s paired step1's class
+        // list with step2's label, so the state was wrong AND a step vanished.
+        let top = r#"
+            <div id="step1" class="ch-suivi-colis-light-info first before ">
+              <div class="ch-suivi-colis-light-picto "></div>
+            </div>
+            <div id="step2" class="ch-suivi-colis-light-info active ">
+              <div class="ch-suivi-colis-light-picto"></div>
+              <div class="ch-suivi-colis-light-text">Delivered</div>
+            </div>"#;
+        let steps = parse_steps(top);
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].label, "Delivered");
+        assert_eq!(
+            steps[0].state, "current",
+            "label must keep its OWN step's state, not the previous step's"
+        );
+    }
+
+    #[test]
+    fn parse_steps_tolerates_trailing_space_in_class() {
+        // Chronopost's templates emit `class="ch-suivi-colis-light-picto "`,
+        // so the text class can carry a trailing space too. Requiring the
+        // quote immediately after the name returned zero steps, silently.
+        let top = r#"<div class="ch-suivi-colis-light-info active ">
+              <div class="ch-suivi-colis-light-text ">Out for delivery</div>
+            </div>"#;
+        let steps = parse_steps(top);
+        assert_eq!(steps.len(), 1, "trailing space must not drop the step");
+        assert_eq!(steps[0].label, "Out for delivery");
     }
 
     #[test]

--- a/crates/webclaw-fetch/src/extractors/mod.rs
+++ b/crates/webclaw-fetch/src/extractors/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod amazon_product;
 pub mod arxiv;
+pub mod chronopost;
 pub mod crates_io;
 pub mod dev_to;
 pub mod docker_hub;
@@ -96,6 +97,7 @@ pub fn list() -> Vec<ExtractorInfo> {
         ebay_listing::INFO,
         etsy_listing::INFO,
         trustpilot_reviews::INFO,
+        chronopost::INFO,
     ]
 }
 
@@ -265,6 +267,16 @@ pub async fn dispatch_by_url(
             youtube_video::extract(client, url)
                 .await
                 .map(|v| (youtube_video::INFO.name, v)),
+        );
+    }
+    // Safe to auto-dispatch: `matches` requires the exact chronopost.fr host
+    // AND a non-empty `listeNumerosLT`, so it can't steal a generic URL. The
+    // tracking page is an AJAX shell that extracts to zero words otherwise.
+    if chronopost::matches(url) {
+        return Some(
+            chronopost::extract(client, url)
+                .await
+                .map(|v| (chronopost::INFO.name, v)),
         );
     }
     // NOTE: shopify_product, shopify_collection, ecommerce_product,
@@ -443,6 +455,12 @@ pub async fn dispatch_by_name(
         n if n == woocommerce_product::INFO.name => {
             run_or_mismatch(woocommerce_product::matches(url), n, url, || {
                 woocommerce_product::extract(client, url)
+            })
+            .await
+        }
+        n if n == chronopost::INFO.name => {
+            run_or_mismatch(chronopost::matches(url), n, url, || {
+                chronopost::extract(client, url)
             })
             .await
         }


### PR DESCRIPTION
## Why

A user reported that `chronopost.fr` could not be scraped. It returned `502 bot_protection_unbypassed` — while opening fine in a normal browser.

It is not a block. A direct fetch returns **HTTP 200 in ~160 ms** with a real page. Two independent bugs were behind the failure.

## 1. `challenge-platform` is not a challenge marker

`cloud.rs::is_bot_protected` matched a bare `challenge-platform`. Cloudflare injects its **JS-detection beacon** — `/cdn-cgi/challenge-platform/scripts/jsd/main.js`, paired with `__CF$cv$params` — into ordinary 200 responses. Any healthy Cloudflare-fronted page carrying it was classified as an interstitial and escalated to the cloud API, which then reported an unsolvable challenge that never existed.

Now matches `challenge-platform/h/` (the orchestrate script a real interstitial loads). `_cf_chl_opt` already covered the common case, so challenge coverage is unchanged.

## 2. The Chronopost tracking page is an AJAX shell

`trackinginfos.js` GETs `/tracking-no-cms/suivi-colis` and injects the result, so the page itself extracts to **zero words**.

That endpoint only returns data when the request carries `X-Requested-With: XMLHttpRequest`. Without it Chronopost serves a **"Site en maintenance" decoy** that reads like a genuine outage — worth knowing, it is an easy hour to lose.

New `chronopost` vertical sends the header and parses the JSON's HTML fragments into typed output: status, milestone progress (`completed`/`current`/`pending`), and the full scan-event history. Emits a named error if the decoy comes back anyway.

`matches()` is strict (exact host + non-empty `listeNumerosLT`), so it is safe in `dispatch_by_url` auto-detect.

## Verification

- `cargo test --workspace --lib` — 654 pass (+7 new)
- `cargo fmt --check --all` — clean
- `cargo clippy --all -- -D warnings` — clean
- `cargo check --target wasm32-unknown-unknown -p webclaw-core`, with and without `--no-default-features` — clean
- `cargo doc --no-deps --workspace` — clean

Verified live end-to-end: `status: "Delayed parcel"`, 5 steps correctly staged, 11 scan events.

> Note: `cargo test --workspace` (without `--lib`) also runs `webclaw-fetch/tests/bench_1k.rs`, a live 1000-site network benchmark.

## Downstream

`webclaw-server` pins this crate by release tag, so it needs a **v0.6.17 tag** before the API can consume either fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)