### PR TITLE
chore(release): 0.6.17 — drop competitor name from zh README, reconcile version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 - **Healthy Cloudflare-fronted pages are no longer mistaken for challenge pages.** Cloudflare adds a small JavaScript-detection snippet to ordinary, successfully served pages. webclaw matched on part of that snippet's path, so any page carrying it was treated as a bot challenge and needlessly escalated to the cloud API — which then reported an unsolvable challenge that was never there. Detection now keys on markers that only appear on a real interstitial, and covers both path forms the snippet is served under.
 
+## [0.6.17] - 2026-08-03
+
+Reconciles the repo with what the MCP registry has been advertising since
+2026-07-22. The registry entry for 0.6.17 was published then, but no matching
+tag was ever cut, so `0.6.16` remained the newest release while the registry
+pointed at a version that did not exist.
+
+### Changed
+- **Dropped a competitor's name from the project description.** The MCP registry
+  manifest was reworded in 0.6.17 (already live); the Chinese README still
+  carried the same phrasing and is now aligned with the English one. Both now
+  describe webclaw on its own terms: open source and self-hostable.
+
 ## [0.6.16] - 2026-07-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-cli"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "clap",
  "dotenvy",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-core"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "ego-tree",
  "once_cell",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-fetch"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-llm"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-mcp"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "dirs",
  "dotenvy",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-pdf"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "pdf-extract",
  "thiserror",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-server"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.6.16"
+version = "0.6.17"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/0xMassi/webclaw"

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -40,7 +40,7 @@
 
 [webclaw.io](https://webclaw.io) 是 webclaw 的托管式网页提取 API。本仓库包含开源的 CLI、MCP 服务器、提取引擎，以及可自托管的服务端。
 
-webclaw 用 Rust 编写，把一个 URL 变成你的工具真正用得上的干净内容——它是一个**开源、可自托管的 Firecrawl 替代方案**。
+webclaw 用 Rust 编写，把一个 URL 变成你的工具真正用得上的干净内容——**开源、可自托管**。
 
 ```bash
 webclaw https://example.com --format markdown


### PR DESCRIPTION
## Two things, both real

### 1. A competitor's name is still live on the repo page

`README_zh-CN.md` described webclaw as a "self-hostable **<competitor>** alternative". The English README had already been changed to a plain statement; the Chinese translation was missed, so the claim stayed visible.

Both now describe webclaw on its own terms — open source and self-hostable.

### 2. The registry advertises a version that was never tagged

The MCP registry entry for **0.6.17** was published on 2026-07-22 with the reworded description. But no `v0.6.17` tag was ever cut, so:

- newest git tag: `v0.6.16`
- workspace `Cargo.toml`: `0.6.16`
- `server.json` / registry: `0.6.17`

The registry has been ahead of the repo for two weeks. This bumps the workspace to `0.6.17` so a tag can be pushed and the two agree.

## What is already correct (checked, not assumed)

The registry's **served** description is clean. Current state of `/v0/servers?search=webclaw`:

| entry | isLatest | description |
|---|---|---|
| 0.1.6 | false | ...alternative |
| 0.6.16 | false | ...alternative |
| **0.6.17** | **true** | ...web content extraction |

The registry keeps immutable per-version history, so the old entries cannot be edited. Only the latest is served to clients, and it is already right.

## Deliberately not touched

`benchmarks/` contains a published comparison against a competitor (numbers, methodology, an API key requirement). That is a technical benchmark rather than a positioning claim, and removing it is a product decision, not a cleanup — flagging rather than deleting.

`examples/firecrawl-compatible-api/` is an interop feature name, not a comparison. Kept.

## Verification

`cargo test --workspace --lib` 669 pass · `cargo fmt --check --all` clean · release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)