### PR TITLE
release: promote staging to main — uncapped crawl, streaming batch, one fetch budget, 0.6.17 reconcile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 - **Healthy Cloudflare-fronted pages are no longer mistaken for challenge pages.** Cloudflare adds a small JavaScript-detection snippet to ordinary, successfully served pages. webclaw matched on part of that snippet's path, so any page carrying it was treated as a bot challenge and needlessly escalated to the cloud API — which then reported an unsolvable challenge that was never there. Detection now keys on markers that only appear on a real interstitial, and covers both path forms the snippet is served under.
 
+## [0.6.17] - 2026-08-03
+
+Reconciles the repo with what the MCP registry has been advertising since
+2026-07-22. The registry entry for 0.6.17 was published then, but no matching
+tag was ever cut, so `0.6.16` remained the newest release while the registry
+pointed at a version that did not exist.
+
+### Changed
+- **Dropped a competitor's name from the project description.** The MCP registry
+  manifest was reworded in 0.6.17 (already live); the Chinese README still
+  carried the same phrasing and is now aligned with the English one. Both now
+  describe webclaw on its own terms: open source and self-hostable.
+
 ## [0.6.16] - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Crawl without a page limit.** `CrawlConfig.max_pages` is now `Option<usize>`; `None` crawls until the site is exhausted or you cancel. Expose it as `--max-pages 0` on the CLI, `max_pages: 0` on the MCP `crawl` tool, and `max_pages: 0` on the self-host server, whose 500-page ceiling is gone. Defaults are unchanged, so a caller who says nothing still gets a bounded crawl.
+- **Streaming batch.** `POST /v1/batch` accepts `"stream": true` and answers with NDJSON — one result per line, written as each URL finishes — so a batch of ten and a batch of ten thousand cost the same in memory. The maximum batch size is gone with it. Backed by a new `FetchClient::fetch_and_extract_batch_stream`, which keeps at most `concurrency` fetches in flight instead of starting one task per URL up front.
+- **Crawl streaming mode.** `CrawlConfig.stream_only` drops each page after reporting it on `progress_tx` instead of collecting it, so peak memory stays flat regardless of page count. This is what makes an unbounded crawl practical; collecting callers are unaffected.
 - **Chronopost parcel tracking extractor.** `webclaw vertical chronopost <tracking-url>` — also available as the `vertical_scrape` MCP tool and `POST /v1/scrape/chronopost` — returns the current status, the milestone progress bar, and the full scan-event history as typed JSON. The tracking page itself renders its content after load, so a plain fetch of it returns an empty document; this extractor reads the underlying data directly.
 
 ### Fixed
+- **A fetch now honours one time budget instead of compounding several.** The HTTP client applies `timeout` twice per attempt — once for the response head, then again for the body — and the retry loop ran two attempts with a pause between them, so a 12-second timeout permitted 49 seconds of wall clock. A new `total_timeout` (default: twice `timeout`) bounds the whole operation, attempts included. A single slow-but-successful page is unaffected; a dead host stops costing four budgets.
 - **Healthy Cloudflare-fronted pages are no longer mistaken for challenge pages.** Cloudflare adds a small JavaScript-detection snippet to ordinary, successfully served pages. webclaw matched on part of that snippet's path, so any page carrying it was treated as a bot challenge and needlessly escalated to the cloud API — which then reported an unsolvable challenge that was never there. Detection now keys on markers that only appear on a real interstitial, and covers both path forms the snippet is served under.
+
+### Performance
+- **Response bodies are no longer copied twice.** Decoding a fetched page to text handed the existing buffer to `String` rather than allocating a second one and copying into it: 500 KB pages went 337 µs → 55 µs, 16 MB went 5.3 ms → 1.5 ms, and peak memory per in-flight fetch halved. The connection pool also no longer caps itself below the client default, which was forcing reconnects on HTTP/1.1 origins under concurrency.
 
 ## [0.6.16] - 2026-07-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3335,6 +3335,7 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "futures-util",
  "serde",
  "serde_json",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-cli"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "clap",
  "dotenvy",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-core"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "ego-tree",
  "once_cell",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-fetch"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-llm"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-mcp"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "dirs",
  "dotenvy",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-pdf"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "pdf-extract",
  "thiserror",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-server"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.6.16"
+version = "0.6.17"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/0xMassi/webclaw"

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -40,7 +40,7 @@
 
 [webclaw.io](https://webclaw.io) 是 webclaw 的托管式网页提取 API。本仓库包含开源的 CLI、MCP 服务器、提取引擎，以及可自托管的服务端。
 
-webclaw 用 Rust 编写，把一个 URL 变成你的工具真正用得上的干净内容——它是一个**开源、可自托管的 Firecrawl 替代方案**。
+webclaw 用 Rust 编写，把一个 URL 变成你的工具真正用得上的干净内容——**开源、可自托管**。
 
 ```bash
 webclaw https://example.com --format markdown

--- a/benchmarks/latency.md
+++ b/benchmarks/latency.md
@@ -56,6 +56,40 @@ HTML genuinely has no content, and a browser render is the correct answer. A
 page tripping on **byte size while carrying real words** would be a false
 positive. The two demand opposite fixes, so measure before concluding.
 
+## Comparing two egress paths
+
+Two traps make A/B egress comparisons produce confident nonsense. Both were hit
+on the first real run here.
+
+**Fast failures win races.** A 403 challenge page arrives quickly, carries a
+body, and raises no transport error. Score it as a success and the egress path
+that gets *blocked* looks faster than the one served the real page. One such row
+produced an apparent "28× speedup" that was a block page timed against a real
+one. Latency percentiles here therefore cover 2xx only, and non-2xx is counted
+separately — but that is a floor, not a ceiling. When comparing two runs, also
+require **body sizes within ~10%** per URL before believing the pair; a soft
+block returns 200 with a much smaller body and slips past a status check.
+
+**The noise floor is bigger than most effects.** Four runs of an *unchanged*
+configuration over the same 200 URLs spanned 1.8× in mean and 2.8× in max, with
+per-URL max/min across identical runs reaching ~10× at p90. A single-run
+difference under roughly 2× carries no information, and a single-URL difference
+of any size carries none at all. To make a comparison mean something:
+
+- **Interleave the arms** per URL (A/B/A/B within the same short window) instead
+  of running all of A then all of B — sequential order alone can manufacture a
+  result.
+- **Include a null arm** — A vs a second instance of A. Any A-vs-B effect has to
+  beat the A-vs-A effect to count.
+- **Deduplicate to backends, not hostnames.** Distinct hostnames routinely share
+  one origin or anycast endpoint, so four URLs behind one backend is one
+  observation. Resolve first and keep one URL per backend.
+- **Report the paired median ratio**, not the difference of aggregate p50s. A
+  single multi-MB URL can supply more than the entire gap between two arms.
+
+Note that a large-object transfer difference is a *bandwidth* question wearing a
+latency costume; separate it rather than letting it drive a p99.
+
 ## Reading the tail
 
 Latency here is heavily tail-weighted: on a representative corpus a low

--- a/benchmarks/latency.md
+++ b/benchmarks/latency.md
@@ -1,0 +1,65 @@
+# Fetch-path latency benchmark
+
+`crates/webclaw-fetch/examples/latency_bench.rs` measures where wall-clock time
+actually goes on the fetch path, separating **network** from **CPU**:
+
+- `fetch_ms` — `FetchClient::fetch`: DNS + TCP + TLS + request + TTFB + body.
+- `extract_ms` — `webclaw_core::extract_with_options`: pure parse + extraction.
+
+This is deliberately different from `benchmarks/methodology.md`, which measures
+extraction *quality* (tokens and fidelity). This one measures *speed*, and its
+job is to say which half is worth optimising before anyone optimises anything.
+
+## Running
+
+```bash
+cargo build --release -p webclaw-fetch --example latency_bench
+
+BENCH_URLS=/path/to/urls.txt \
+BENCH_CONCURRENCY=8 \
+BENCH_LIMIT=200 \
+  ./target/release/examples/latency_bench > run.jsonl 2> run.summary
+```
+
+| Env | Default | Meaning |
+|---|---|---|
+| `BENCH_URLS` | *(required)* | File of URLs, one per line |
+| `BENCH_CONCURRENCY` | 8 | In-flight requests |
+| `BENCH_LIMIT` | all | Cap URLs read |
+| `BENCH_TIMEOUT_SECS` | 12 | Per-request timeout |
+| `WEBCLAW_PROXY` | unset | Optional proxy |
+
+The URL list is passed in at runtime and is **never committed** — a realistic
+corpus is drawn from whatever traffic you actually serve, which is not public
+data. Lines may carry extra `|`-separated columns (only the first is read), so a
+CSV/DB export can be fed in unchanged; `#` comments and blanks are skipped.
+
+stdout is JSONL (one object per URL: status, timings, bytes, words, error) so
+runs can be diffed over time. stderr carries the percentile summary.
+
+## Interpreting a run
+
+The summary prints `p50/p90/p99/max` for fetch, extract, and total, plus:
+
+- **`extract share of measured time`** — if this is low single digits, the
+  extractor is not the bottleneck and parser micro-optimisation is wasted
+  effort. Attack the network path instead.
+- **`200s that would trip the thin-body escalation rule`** — pages returning
+  HTTP 200 with under 10 KB of HTML *or* under 50 extracted words. Downstream
+  consumers treat these as "not the real page" and re-fetch them through a
+  browser, which costs an order of magnitude more than the direct fetch. This
+  count is the size of that exposure *before* any escalation runs.
+
+That last number is worth splitting by cause when it looks high. A page tripping
+on **word count with a large HTML body** is a client-rendered shell — the static
+HTML genuinely has no content, and a browser render is the correct answer. A
+page tripping on **byte size while carrying real words** would be a false
+positive. The two demand opposite fixes, so measure before concluding.
+
+## Reading the tail
+
+Latency here is heavily tail-weighted: on a representative corpus a low
+single-digit percentage of URLs can account for roughly a third of total fetch
+time, and `p99` tends to sit at whatever `BENCH_TIMEOUT_SECS` is set to — that
+is the timeout wall, not a measurement. Compare `p50` for typical cost and count
+requests at the timeout separately; averaging across both hides each.

--- a/crates/webclaw-cli/src/main.rs
+++ b/crates/webclaw-cli/src/main.rs
@@ -277,7 +277,8 @@ struct Cli {
     #[arg(long, default_value = "1")]
     depth: usize,
 
-    /// Max pages to crawl [default: 20]
+    /// Max pages to crawl. `0` = no limit: crawl until the site is exhausted
+    /// or you interrupt it [default: 20]
     #[arg(long, default_value = "20")]
     max_pages: usize,
 
@@ -1450,7 +1451,7 @@ fn print_map_output(entries: &[SitemapEntry], format: &OutputFormat) {
 }
 
 /// Format a streaming progress line for a completed page.
-fn format_progress(page: &PageResult, index: usize, max_pages: usize) -> String {
+fn format_progress(page: &PageResult, index: usize, max_pages: Option<usize>) -> String {
     let status = if page.error.is_some() { "ERR" } else { "OK " };
     let timing = format!("{}ms", page.elapsed.as_millis());
     let detail = if let Some(ref extraction) = page.extraction {
@@ -1460,10 +1461,9 @@ fn format_progress(page: &PageResult, index: usize, max_pages: usize) -> String 
     } else {
         String::new()
     };
-    format!(
-        "[{index}/{max_pages}] {status} {} ({timing}{detail})",
-        page.url
-    )
+    // Uncapped crawls have no denominator to show, so print a running count.
+    let of = max_pages.map_or(String::new(), |m| format!("/{m}"));
+    format!("[{index}{of}] {status} {} ({timing}{detail})", page.url)
 }
 
 async fn run_crawl(cli: &Cli) -> Result<(), String> {
@@ -1509,7 +1509,12 @@ async fn run_crawl(cli: &Cli) -> Result<(), String> {
     let config = CrawlConfig {
         fetch: build_fetch_config(cli),
         max_depth: cli.depth,
-        max_pages: cli.max_pages,
+        // `--max-pages 0` = no cap.
+        max_pages: (cli.max_pages > 0).then_some(cli.max_pages),
+        // The CLI renders a document from the collected pages at the end, so
+        // it keeps them. An uncapped crawl therefore grows with the site —
+        // acceptable on a workstation, and Ctrl+C saves resumable state.
+        stream_only: false,
         concurrency: cli.concurrency,
         delay: std::time::Duration::from_millis(cli.delay),
         path_prefix: cli.path_prefix.clone(),
@@ -1534,7 +1539,8 @@ async fn run_crawl(cli: &Cli) -> Result<(), String> {
             );
         });
 
-    let max_pages = cli.max_pages;
+    // `None` = uncapped, so the progress line shows a running count only.
+    let max_pages = (cli.max_pages > 0).then_some(cli.max_pages);
     let completed_offset = resume_state.as_ref().map_or(0, |s| s.completed_pages);
 
     // Spawn background task to print streaming progress to stderr
@@ -1562,14 +1568,14 @@ async fn run_crawl(cli: &Cli) -> Result<(), String> {
                 url,
                 &result.visited,
                 &result.remaining_frontier,
-                completed_offset + result.pages.len(),
+                completed_offset + result.total,
                 cli.max_pages,
                 cli.depth,
             )?;
             eprintln!(
                 "Crawl state saved to {} ({} pages completed). Resume with --crawl-state {}",
                 path.display(),
-                completed_offset + result.pages.len(),
+                completed_offset + result.total,
                 path.display(),
             );
         }

--- a/crates/webclaw-fetch/examples/latency_bench.rs
+++ b/crates/webclaw-fetch/examples/latency_bench.rs
@@ -1,0 +1,234 @@
+//! Fetch-path latency benchmark over a real URL list.
+//!
+//! Separates network time from CPU time so it is clear which one to attack:
+//! `FetchClient::fetch` (DNS + TCP + TLS + TTFB + body) is reported apart from
+//! `webclaw_core::extract_with_options` (pure parse + extraction).
+//!
+//! The URL list is supplied at runtime and never committed — production URLs
+//! are customer data and this repo is public.
+//!
+//! ```text
+//! BENCH_URLS=/path/to/urls.txt \
+//! BENCH_CONCURRENCY=8 \
+//! BENCH_LIMIT=200 \
+//!   cargo run --release -p webclaw-fetch --example latency_bench
+//! ```
+//!
+//! Input: one URL per line. Lines may carry extra `|`-separated columns (the
+//! first field is used), so a DB export can be fed in unchanged. `#` comments
+//! and blank lines are skipped.
+//!
+//! Writes JSONL to stdout (one object per URL) and a percentile summary to
+//! stderr, so `> runs/today.jsonl` keeps the raw data while the summary stays
+//! on the terminal.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use webclaw_fetch::{BrowserProfile, FetchClient, FetchConfig};
+
+/// One measured URL.
+struct Row {
+    url: String,
+    status: Option<u16>,
+    fetch_ms: u128,
+    extract_ms: u128,
+    bytes: usize,
+    words: usize,
+    error: Option<String>,
+}
+
+impl Row {
+    fn to_json(&self) -> String {
+        // Hand-rolled so the example pulls in no serde_json dev-dependency.
+        let esc = |s: &str| s.replace('\\', "\\\\").replace('"', "\\\"");
+        format!(
+            r#"{{"url":"{}","status":{},"fetch_ms":{},"extract_ms":{},"bytes":{},"words":{},"error":{}}}"#,
+            esc(&self.url),
+            self.status.map_or("null".into(), |s| s.to_string()),
+            self.fetch_ms,
+            self.extract_ms,
+            self.bytes,
+            self.words,
+            self.error
+                .as_ref()
+                .map_or("null".to_string(), |e| format!("\"{}\"", esc(e))),
+        )
+    }
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn percentile(sorted: &[u128], p: f64) -> u128 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    // Nearest-rank; index is clamped so p=1.0 lands on the last element.
+    let idx = ((sorted.len() as f64 * p).ceil() as usize).saturating_sub(1);
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn summarize(label: &str, mut v: Vec<u128>) {
+    if v.is_empty() {
+        eprintln!("{label:<12} (no samples)");
+        return;
+    }
+    v.sort_unstable();
+    let sum: u128 = v.iter().sum();
+    eprintln!(
+        "{label:<12} n={:<5} mean={:<7} p50={:<7} p90={:<7} p99={:<7} max={}",
+        v.len(),
+        sum / v.len() as u128,
+        percentile(&v, 0.50),
+        percentile(&v, 0.90),
+        percentile(&v, 0.99),
+        v[v.len() - 1],
+    );
+}
+
+#[tokio::main]
+async fn main() {
+    let path = std::env::var("BENCH_URLS")
+        .expect("set BENCH_URLS to a file of URLs (one per line, extra |-columns ignored)");
+    let concurrency = env_usize("BENCH_CONCURRENCY", 8);
+    let limit = env_usize("BENCH_LIMIT", usize::MAX);
+    let timeout_secs = env_usize("BENCH_TIMEOUT_SECS", 12) as u64;
+
+    let raw = std::fs::read_to_string(&path).expect("read BENCH_URLS file");
+    let urls: Vec<String> = raw
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .filter_map(|l| l.split('|').next())
+        .filter(|u| u.starts_with("http"))
+        .map(str::to_string)
+        .take(limit)
+        .collect();
+
+    eprintln!(
+        "urls={} concurrency={} timeout={}s",
+        urls.len(),
+        concurrency,
+        timeout_secs
+    );
+
+    let client = Arc::new(
+        FetchClient::new(FetchConfig {
+            browser: BrowserProfile::Chrome,
+            proxy: std::env::var("WEBCLAW_PROXY").ok(),
+            timeout: Duration::from_secs(timeout_secs),
+            ..Default::default()
+        })
+        .expect("build client"),
+    );
+
+    let started = Instant::now();
+    let sem = Arc::new(tokio::sync::Semaphore::new(concurrency));
+    let mut tasks = Vec::with_capacity(urls.len());
+
+    for url in urls {
+        let client = Arc::clone(&client);
+        let sem = Arc::clone(&sem);
+        tasks.push(tokio::spawn(async move {
+            let _permit = sem.acquire().await.expect("semaphore open");
+
+            let t0 = Instant::now();
+            let fetched = client.fetch(&url).await;
+            let fetch_ms = t0.elapsed().as_millis();
+
+            match fetched {
+                Ok(r) => {
+                    let bytes = r.html.len();
+                    let t1 = Instant::now();
+                    let extraction = webclaw_core::extract_with_options(
+                        &r.html,
+                        Some(&r.url),
+                        &webclaw_core::ExtractionOptions::default(),
+                    );
+                    let extract_ms = t1.elapsed().as_millis();
+                    let words = extraction
+                        .as_ref()
+                        .map(|e| e.content.plain_text.split_whitespace().count())
+                        .unwrap_or(0);
+                    Row {
+                        url,
+                        status: Some(r.status),
+                        fetch_ms,
+                        extract_ms,
+                        bytes,
+                        words,
+                        error: extraction.err().map(|e| e.to_string()),
+                    }
+                }
+                Err(e) => Row {
+                    url,
+                    status: None,
+                    fetch_ms,
+                    extract_ms: 0,
+                    bytes: 0,
+                    words: 0,
+                    error: Some(e.to_string()),
+                },
+            }
+        }));
+    }
+
+    let mut rows = Vec::with_capacity(tasks.len());
+    for t in tasks {
+        match t.await {
+            Ok(r) => rows.push(r),
+            Err(e) => eprintln!("task panicked: {e}"),
+        }
+    }
+    let wall = started.elapsed();
+
+    for r in &rows {
+        println!("{}", r.to_json());
+    }
+
+    let ok: Vec<&Row> = rows.iter().filter(|r| r.error.is_none()).collect();
+    let failed = rows.len() - ok.len();
+
+    eprintln!("\n=== latency (ms) ===");
+    summarize("fetch", ok.iter().map(|r| r.fetch_ms).collect());
+    summarize("extract", ok.iter().map(|r| r.extract_ms).collect());
+    summarize(
+        "total",
+        ok.iter().map(|r| r.fetch_ms + r.extract_ms).collect(),
+    );
+
+    let fetch_sum: u128 = ok.iter().map(|r| r.fetch_ms).sum();
+    let extract_sum: u128 = ok.iter().map(|r| r.extract_ms).sum();
+    let cpu_share = if fetch_sum + extract_sum > 0 {
+        100.0 * extract_sum as f64 / (fetch_sum + extract_sum) as f64
+    } else {
+        0.0
+    };
+
+    eprintln!("\n=== shape ===");
+    eprintln!("ok={} failed={}", ok.len(), failed);
+    eprintln!("extract share of measured time: {cpu_share:.1}%");
+    eprintln!(
+        "wall={:.1}s  throughput={:.1} url/s",
+        wall.as_secs_f64(),
+        rows.len() as f64 / wall.as_secs_f64().max(0.001)
+    );
+
+    // A page that returns 200 but almost no text is what makes the production
+    // pipeline escalate to a browser; count them so the benchmark shows how
+    // much of the corpus is at risk of that before any escalation runs.
+    let thin = ok
+        .iter()
+        .filter(|r| r.status == Some(200) && (r.bytes < 10_000 || r.words < 50))
+        .count();
+    eprintln!(
+        "200s that would trip the thin-body escalation rule: {thin}/{} ({:.1}%)",
+        ok.len(),
+        100.0 * thin as f64 / ok.len().max(1) as f64
+    );
+}

--- a/crates/webclaw-fetch/examples/latency_bench.rs
+++ b/crates/webclaw-fetch/examples/latency_bench.rs
@@ -236,8 +236,18 @@ async fn main() {
         println!("{}", r.to_json());
     }
 
-    let ok: Vec<&Row> = rows.iter().filter(|r| r.error.is_none()).collect();
-    let failed = rows.len() - ok.len();
+    // A transport error is not the only kind of failure. A 403 challenge page
+    // arrives fast, carries a body, and sets no error — so counting it as a
+    // successful fetch lets FAST FAILURES WIN RACES: an egress path that gets
+    // blocked looks quicker than one that is served the real page. Latency is
+    // therefore only summarised over 2xx responses, and non-2xx is reported
+    // separately rather than folded into the percentiles.
+    let ok: Vec<&Row> = rows
+        .iter()
+        .filter(|r| r.error.is_none() && matches!(r.status, Some(200..=299)))
+        .collect();
+    let transport_err = rows.iter().filter(|r| r.error.is_some()).count();
+    let non_2xx = rows.len() - ok.len() - transport_err;
 
     eprintln!("\n=== latency (ms) ===");
     summarize("fetch", ok.iter().map(|r| r.fetch_ms).collect());
@@ -258,11 +268,28 @@ async fn main() {
     let total_bytes: usize = ok.iter().map(|r| r.bytes).sum();
     eprintln!("\n=== shape ===");
     eprintln!(
-        "ok={} failed={} success={:.1}%",
+        "2xx={} non-2xx={} transport-err={} success={:.1}%",
         ok.len(),
-        failed,
+        non_2xx,
+        transport_err,
         100.0 * ok.len() as f64 / rows.len().max(1) as f64
     );
+    if non_2xx > 0 {
+        // Worth calling out: a scenario with many non-2xx responses may look
+        // fast purely because it was blocked quickly.
+        let mut codes: Vec<u16> = rows
+            .iter()
+            .filter(|r| r.error.is_none())
+            .filter_map(|r| r.status)
+            .filter(|s| !(200..=299).contains(s))
+            .collect();
+        codes.sort_unstable();
+        codes.dedup();
+        eprintln!(
+            "  non-2xx status codes seen: {:?} — excluded from the latency percentiles above",
+            codes
+        );
+    }
     eprintln!(
         "bytes fetched: {:.1} MB (metered egress is billed on this)",
         total_bytes as f64 / 1_048_576.0

--- a/crates/webclaw-fetch/examples/latency_bench.rs
+++ b/crates/webclaw-fetch/examples/latency_bench.rs
@@ -21,6 +21,23 @@
 //! Writes JSONL to stdout (one object per URL) and a percentile summary to
 //! stderr, so `> runs/today.jsonl` keeps the raw data while the summary stays
 //! on the terminal.
+//!
+//! ## Egress
+//!
+//! | Env | Effect |
+//! |---|---|
+//! | *(neither set)* | Direct from this host |
+//! | `WEBCLAW_PROXY` | Every request through one proxy |
+//! | `BENCH_PROXY_FILE` | Rotating pool, one client per proxy URL in the file |
+//!
+//! `BENCH_PROXY_FILE` exercises the same rotating-pool path production uses,
+//! so pool behaviour (per-host client affinity, connection reuse across a
+//! pool) is measured rather than assumed. Proxy files hold credentials: keep
+//! them outside the repo.
+//!
+//! `BENCH_LABEL` tags every row so runs across different egress paths can be
+//! concatenated and compared. Total bytes fetched is reported because metered
+//! egress (residential proxies especially) is billed per GB.
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -29,6 +46,7 @@ use webclaw_fetch::{BrowserProfile, FetchClient, FetchConfig};
 
 /// One measured URL.
 struct Row {
+    label: String,
     url: String,
     status: Option<u16>,
     fetch_ms: u128,
@@ -43,7 +61,8 @@ impl Row {
         // Hand-rolled so the example pulls in no serde_json dev-dependency.
         let esc = |s: &str| s.replace('\\', "\\\\").replace('"', "\\\"");
         format!(
-            r#"{{"url":"{}","status":{},"fetch_ms":{},"extract_ms":{},"bytes":{},"words":{},"error":{}}}"#,
+            r#"{{"label":"{}","url":"{}","status":{},"fetch_ms":{},"extract_ms":{},"bytes":{},"words":{},"error":{}}}"#,
+            esc(&self.label),
             esc(&self.url),
             self.status.map_or("null".into(), |s| s.to_string()),
             self.fetch_ms,
@@ -110,17 +129,40 @@ async fn main() {
         .take(limit)
         .collect();
 
+    let label = std::env::var("BENCH_LABEL").unwrap_or_else(|_| "direct".to_string());
+
+    // A proxy file builds the rotating pool; a single WEBCLAW_PROXY does not.
+    let proxy_pool: Vec<String> = match std::env::var("BENCH_PROXY_FILE") {
+        Ok(p) => std::fs::read_to_string(&p)
+            .expect("read BENCH_PROXY_FILE")
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty() && !l.starts_with('#'))
+            .map(str::to_string)
+            .collect(),
+        Err(_) => Vec::new(),
+    };
+
     eprintln!(
-        "urls={} concurrency={} timeout={}s",
+        "label={} urls={} concurrency={} timeout={}s egress={}",
+        label,
         urls.len(),
         concurrency,
-        timeout_secs
+        timeout_secs,
+        if !proxy_pool.is_empty() {
+            format!("pool of {}", proxy_pool.len())
+        } else if std::env::var("WEBCLAW_PROXY").is_ok() {
+            "single proxy".to_string()
+        } else {
+            "direct".to_string()
+        }
     );
 
     let client = Arc::new(
         FetchClient::new(FetchConfig {
             browser: BrowserProfile::Chrome,
             proxy: std::env::var("WEBCLAW_PROXY").ok(),
+            proxy_pool,
             timeout: Duration::from_secs(timeout_secs),
             ..Default::default()
         })
@@ -134,6 +176,7 @@ async fn main() {
     for url in urls {
         let client = Arc::clone(&client);
         let sem = Arc::clone(&sem);
+        let label = label.clone();
         tasks.push(tokio::spawn(async move {
             let _permit = sem.acquire().await.expect("semaphore open");
 
@@ -156,6 +199,7 @@ async fn main() {
                         .map(|e| e.content.plain_text.split_whitespace().count())
                         .unwrap_or(0);
                     Row {
+                        label,
                         url,
                         status: Some(r.status),
                         fetch_ms,
@@ -166,6 +210,7 @@ async fn main() {
                     }
                 }
                 Err(e) => Row {
+                    label,
                     url,
                     status: None,
                     fetch_ms,
@@ -210,8 +255,18 @@ async fn main() {
         0.0
     };
 
+    let total_bytes: usize = ok.iter().map(|r| r.bytes).sum();
     eprintln!("\n=== shape ===");
-    eprintln!("ok={} failed={}", ok.len(), failed);
+    eprintln!(
+        "ok={} failed={} success={:.1}%",
+        ok.len(),
+        failed,
+        100.0 * ok.len() as f64 / rows.len().max(1) as f64
+    );
+    eprintln!(
+        "bytes fetched: {:.1} MB (metered egress is billed on this)",
+        total_bytes as f64 / 1_048_576.0
+    );
     eprintln!("extract share of measured time: {cpu_share:.1}%");
     eprintln!(
         "wall={:.1}s  throughput={:.1} url/s",

--- a/crates/webclaw-fetch/src/client.rs
+++ b/crates/webclaw-fetch/src/client.rs
@@ -110,16 +110,31 @@ fn check_body_ceiling(buffered: usize, next_chunk: usize) -> Result<(), FetchErr
 }
 
 impl Response {
-    /// Buffer a wreq response into an owned Response.
+    /// Buffer a wreq response into an owned Response, bounded in BOTH bytes
+    /// and time.
     ///
     /// Rejects bodies that advertise a Content-Length beyond
     /// [`MAX_BODY_BYTES`] before we pay any allocation, then streams the
-    /// body chunk-by-chunk while enforcing a running ceiling. `chunk()`
+    /// body chunk-by-chunk while enforcing a running ceiling. The stream
     /// yields *post-decompression* bytes (gzip/brotli/zstd/deflate are
     /// negotiated), so a tiny compressed payload that inflates to
     /// gigabytes is aborted as soon as the accumulated size crosses the
     /// cap — it never gets fully buffered in memory.
-    async fn from_wreq(resp: wreq::Response) -> Result<Self, FetchError> {
+    ///
+    /// `stall` bounds how long the body may go with NO new bytes. The
+    /// client-level `.timeout()` does not cover this loop — it governs getting
+    /// a response head — so without a deadline here a server that stops
+    /// sending mid-body holds the connection open indefinitely and a fetch
+    /// runs well past the configured timeout. The size ceiling alone does not
+    /// help: a stalled stream never reaches it.
+    ///
+    /// Deliberately an idle timeout rather than a total-body deadline. A total
+    /// deadline penalises *size* instead of *stalling*: a legitimate multi-MB
+    /// download (a CSV export, a large PDF) is slow because there is a lot of
+    /// it, and killing that is a regression, not a fix. A stalled peer is
+    /// distinguishable because it stops delivering chunks — so the clock
+    /// resets on every chunk and only silence trips it.
+    async fn from_wreq(resp: wreq::Response, stall: Duration) -> Result<Self, FetchError> {
         if let Some(len) = resp.content_length()
             && len > MAX_BODY_BYTES
         {
@@ -136,10 +151,23 @@ impl Response {
         // compression bomb is aborted before it is fully buffered in memory.
         let mut buf = bytes::BytesMut::new();
         let mut stream = resp.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(|e| FetchError::BodyDecode(e.to_string()))?;
-            check_body_ceiling(buf.len(), chunk.len())?;
-            buf.extend_from_slice(&chunk);
+        loop {
+            match tokio::time::timeout(stall, stream.next()).await {
+                // No chunk within the idle window: the peer went quiet.
+                Err(_) => {
+                    return Err(FetchError::BodyDecode(format!(
+                        "response body stalled: no data for {}ms after {} bytes",
+                        stall.as_millis(),
+                        buf.len()
+                    )));
+                }
+                Ok(None) => break,
+                Ok(Some(chunk)) => {
+                    let chunk = chunk.map_err(|e| FetchError::BodyDecode(e.to_string()))?;
+                    check_body_ceiling(buf.len(), chunk.len())?;
+                    buf.extend_from_slice(&chunk);
+                }
+            }
         }
 
         Ok(Self {
@@ -207,6 +235,10 @@ pub struct FetchClient {
     /// out. Stored as `Arc` so cloning a `FetchClient` (common in
     /// axum state) doesn't clone the underlying reqwest pool.
     cloud: Option<std::sync::Arc<crate::cloud::CloudClient>>,
+    /// Configured per-request timeout, retained so the body-read deadline can
+    /// be derived from it. The wreq client's own `.timeout()` governs getting
+    /// a response head; it does not bound streaming the body.
+    timeout: Duration,
 }
 
 impl FetchClient {
@@ -268,7 +300,19 @@ impl FetchClient {
             pool,
             pdf_mode,
             cloud: None,
+            timeout: config.timeout,
         })
+    }
+
+    /// How long the body stream may go with no new bytes before it counts as
+    /// stalled.
+    ///
+    /// Reuses the configured request timeout: a peer that has sent nothing for
+    /// as long as we were willing to wait for the whole response head is not
+    /// coming back. This is an *idle* window, not a total budget, so a large
+    /// but healthy download is unaffected however long it legitimately takes.
+    fn body_stall_timeout(&self) -> Duration {
+        self.timeout
     }
 
     /// Attach a cloud-fallback client. Returns `self` so it composes in
@@ -406,7 +450,7 @@ impl FetchClient {
             req = req.header(*k, *v);
         }
         let resp = req.send().await?;
-        let response = Response::from_wreq(resp).await?;
+        let response = Response::from_wreq(resp, self.body_stall_timeout()).await?;
         response_to_result(response, start)
     }
 
@@ -482,7 +526,7 @@ impl FetchClient {
         let url = parsed_url.as_str();
         let client = self.pick_client(url);
         let resp = client.get(url).send().await?;
-        let response = Response::from_wreq(resp).await?;
+        let response = Response::from_wreq(resp, self.body_stall_timeout()).await?;
         Ok((response.status(), response.into_body()))
     }
 
@@ -520,7 +564,7 @@ impl FetchClient {
         let start = Instant::now();
         let client = self.pick_client(url);
         let resp = client.get(url).send().await?;
-        let mut response = Response::from_wreq(resp).await?;
+        let mut response = Response::from_wreq(resp, self.body_stall_timeout()).await?;
 
         // Cookie warmup: if we get a challenge page, visit the homepage first
         // to collect Akamai cookies (_abck, bm_sz, etc.), then retry.
@@ -530,7 +574,7 @@ impl FetchClient {
             debug!("challenge detected, warming cookies via {homepage}");
             let _ = self.fetch(&homepage).await;
             let resp = client.get(url).send().await?;
-            response = Response::from_wreq(resp).await?;
+            response = Response::from_wreq(resp, self.body_stall_timeout()).await?;
             debug!("retried after cookie warmup: status={}", response.status());
         }
 
@@ -900,6 +944,41 @@ async fn collect_ordered<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn client_with_timeout(secs: u64) -> FetchClient {
+        FetchClient::new(FetchConfig {
+            timeout: Duration::from_secs(secs),
+            ..Default::default()
+        })
+        .expect("build client")
+    }
+
+    #[test]
+    fn body_stall_timeout_tracks_the_configured_timeout() {
+        assert_eq!(
+            client_with_timeout(10).body_stall_timeout(),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            client_with_timeout(3).body_stall_timeout(),
+            Duration::from_secs(3)
+        );
+    }
+
+    /// The stall window is an IDLE timeout, not a total-body deadline: it must
+    /// not depend on how long the request has already been running, or a large
+    /// healthy download gets killed for being large.
+    #[tokio::test]
+    async fn body_stall_timeout_is_independent_of_elapsed_time() {
+        let c = client_with_timeout(5);
+        let before = c.body_stall_timeout();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            before,
+            c.body_stall_timeout(),
+            "idle window must not shrink as the request ages"
+        );
+    }
 
     #[test]
     fn test_batch_result_struct() {

--- a/crates/webclaw-fetch/src/client.rs
+++ b/crates/webclaw-fetch/src/client.rs
@@ -757,6 +757,51 @@ impl FetchClient {
         collect_ordered(handles, urls.len()).await
     }
 
+    /// Fetch and extract many URLs, yielding each result as it completes.
+    ///
+    /// Prefer this over [`fetch_and_extract_batch`](Self::fetch_and_extract_batch)
+    /// for large inputs. That one spawns a task per URL up front and collects
+    /// everything into a `Vec`, so both task count and memory scale with the
+    /// input — which is what forces callers to impose an arbitrary maximum
+    /// batch size. This polls at most `concurrency` futures at a time and hands
+    /// each result straight to the consumer, so a batch of ten URLs and a batch
+    /// of ten thousand cost the same at rest and no cap is needed.
+    ///
+    /// Results arrive in **completion order**, not input order — that is the
+    /// point of streaming. Use `fetch_and_extract_batch` when order matters and
+    /// the input is small enough to buffer.
+    ///
+    /// ```ignore
+    /// use futures_util::StreamExt;
+    /// let mut s = client.fetch_and_extract_batch_stream(urls, 10, opts);
+    /// while let Some(res) = s.next().await {
+    ///     // write it out; nothing accumulates
+    /// }
+    /// ```
+    pub fn fetch_and_extract_batch_stream(
+        self: &Arc<Self>,
+        urls: Vec<String>,
+        concurrency: usize,
+        options: webclaw_core::ExtractionOptions,
+        // `use<>`: the stream clones the Arc internally and borrows nothing,
+        // so it must not capture `&self`'s lifetime — otherwise callers cannot
+        // return it from the scope that built it (e.g. an axum handler
+        // streaming a response body).
+    ) -> impl futures_util::Stream<Item = BatchExtractResult> + use<> {
+        let client = Arc::clone(self);
+        let options = Arc::new(options);
+        futures_util::stream::iter(urls.into_iter().map(move |url| {
+            let client = Arc::clone(&client);
+            let options = Arc::clone(&options);
+            async move {
+                let result = client.fetch_and_extract_with_options(&url, &options).await;
+                BatchExtractResult { url, result }
+            }
+        }))
+        // Bounds in-flight work without materialising a task per URL.
+        .buffer_unordered(concurrency.max(1))
+    }
+
     /// Returns the number of proxies in the rotation pool, or 0 if static mode.
     pub fn proxy_pool_size(&self) -> usize {
         match &self.pool {
@@ -1000,6 +1045,49 @@ mod tests {
             headers: http::HeaderMap::new(),
             body,
         }
+    }
+
+    #[tokio::test]
+    async fn batch_stream_yields_every_url_without_buffering_them() {
+        use futures_util::StreamExt;
+
+        // All unroutable, so each fails fast — the point here is the stream
+        // contract (every input yields exactly one result), not the fetching.
+        let urls: Vec<String> = (0..25)
+            .map(|i| format!("https://nonexistent-{i}.invalid/"))
+            .collect();
+        let expected: std::collections::HashSet<String> = urls.iter().cloned().collect();
+
+        let client = Arc::new(FetchClient::new(FetchConfig::default()).expect("build client"));
+        let mut seen = std::collections::HashSet::new();
+        let mut stream = client.fetch_and_extract_batch_stream(
+            urls,
+            8,
+            webclaw_core::ExtractionOptions::default(),
+        );
+        while let Some(res) = stream.next().await {
+            assert!(
+                seen.insert(res.url),
+                "each URL must be yielded exactly once"
+            );
+        }
+        assert_eq!(seen, expected, "every input URL must produce a result");
+    }
+
+    #[tokio::test]
+    async fn batch_stream_survives_zero_concurrency() {
+        use futures_util::StreamExt;
+        let client = Arc::new(FetchClient::new(FetchConfig::default()).expect("build client"));
+        // `buffer_unordered(0)` would stall forever; the API clamps it.
+        let mut stream = client.fetch_and_extract_batch_stream(
+            vec!["https://nonexistent.invalid/".to_string()],
+            0,
+            webclaw_core::ExtractionOptions::default(),
+        );
+        assert!(
+            stream.next().await.is_some(),
+            "must not deadlock at concurrency 0"
+        );
     }
 
     #[test]

--- a/crates/webclaw-fetch/src/client.rs
+++ b/crates/webclaw-fetch/src/client.rs
@@ -110,31 +110,16 @@ fn check_body_ceiling(buffered: usize, next_chunk: usize) -> Result<(), FetchErr
 }
 
 impl Response {
-    /// Buffer a wreq response into an owned Response, bounded in BOTH bytes
-    /// and time.
+    /// Buffer a wreq response into an owned Response.
     ///
     /// Rejects bodies that advertise a Content-Length beyond
     /// [`MAX_BODY_BYTES`] before we pay any allocation, then streams the
-    /// body chunk-by-chunk while enforcing a running ceiling. The stream
+    /// body chunk-by-chunk while enforcing a running ceiling. `chunk()`
     /// yields *post-decompression* bytes (gzip/brotli/zstd/deflate are
     /// negotiated), so a tiny compressed payload that inflates to
     /// gigabytes is aborted as soon as the accumulated size crosses the
     /// cap — it never gets fully buffered in memory.
-    ///
-    /// `stall` bounds how long the body may go with NO new bytes. The
-    /// client-level `.timeout()` does not cover this loop — it governs getting
-    /// a response head — so without a deadline here a server that stops
-    /// sending mid-body holds the connection open indefinitely and a fetch
-    /// runs well past the configured timeout. The size ceiling alone does not
-    /// help: a stalled stream never reaches it.
-    ///
-    /// Deliberately an idle timeout rather than a total-body deadline. A total
-    /// deadline penalises *size* instead of *stalling*: a legitimate multi-MB
-    /// download (a CSV export, a large PDF) is slow because there is a lot of
-    /// it, and killing that is a regression, not a fix. A stalled peer is
-    /// distinguishable because it stops delivering chunks — so the clock
-    /// resets on every chunk and only silence trips it.
-    async fn from_wreq(resp: wreq::Response, stall: Duration) -> Result<Self, FetchError> {
+    async fn from_wreq(resp: wreq::Response) -> Result<Self, FetchError> {
         if let Some(len) = resp.content_length()
             && len > MAX_BODY_BYTES
         {
@@ -151,23 +136,10 @@ impl Response {
         // compression bomb is aborted before it is fully buffered in memory.
         let mut buf = bytes::BytesMut::new();
         let mut stream = resp.bytes_stream();
-        loop {
-            match tokio::time::timeout(stall, stream.next()).await {
-                // No chunk within the idle window: the peer went quiet.
-                Err(_) => {
-                    return Err(FetchError::BodyDecode(format!(
-                        "response body stalled: no data for {}ms after {} bytes",
-                        stall.as_millis(),
-                        buf.len()
-                    )));
-                }
-                Ok(None) => break,
-                Ok(Some(chunk)) => {
-                    let chunk = chunk.map_err(|e| FetchError::BodyDecode(e.to_string()))?;
-                    check_body_ceiling(buf.len(), chunk.len())?;
-                    buf.extend_from_slice(&chunk);
-                }
-            }
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| FetchError::BodyDecode(e.to_string()))?;
+            check_body_ceiling(buf.len(), chunk.len())?;
+            buf.extend_from_slice(&chunk);
         }
 
         Ok(Self {
@@ -235,10 +207,6 @@ pub struct FetchClient {
     /// out. Stored as `Arc` so cloning a `FetchClient` (common in
     /// axum state) doesn't clone the underlying reqwest pool.
     cloud: Option<std::sync::Arc<crate::cloud::CloudClient>>,
-    /// Configured per-request timeout, retained so the body-read deadline can
-    /// be derived from it. The wreq client's own `.timeout()` governs getting
-    /// a response head; it does not bound streaming the body.
-    timeout: Duration,
 }
 
 impl FetchClient {
@@ -300,19 +268,7 @@ impl FetchClient {
             pool,
             pdf_mode,
             cloud: None,
-            timeout: config.timeout,
         })
-    }
-
-    /// How long the body stream may go with no new bytes before it counts as
-    /// stalled.
-    ///
-    /// Reuses the configured request timeout: a peer that has sent nothing for
-    /// as long as we were willing to wait for the whole response head is not
-    /// coming back. This is an *idle* window, not a total budget, so a large
-    /// but healthy download is unaffected however long it legitimately takes.
-    fn body_stall_timeout(&self) -> Duration {
-        self.timeout
     }
 
     /// Attach a cloud-fallback client. Returns `self` so it composes in
@@ -450,7 +406,7 @@ impl FetchClient {
             req = req.header(*k, *v);
         }
         let resp = req.send().await?;
-        let response = Response::from_wreq(resp, self.body_stall_timeout()).await?;
+        let response = Response::from_wreq(resp).await?;
         response_to_result(response, start)
     }
 
@@ -526,7 +482,7 @@ impl FetchClient {
         let url = parsed_url.as_str();
         let client = self.pick_client(url);
         let resp = client.get(url).send().await?;
-        let response = Response::from_wreq(resp, self.body_stall_timeout()).await?;
+        let response = Response::from_wreq(resp).await?;
         Ok((response.status(), response.into_body()))
     }
 
@@ -564,7 +520,7 @@ impl FetchClient {
         let start = Instant::now();
         let client = self.pick_client(url);
         let resp = client.get(url).send().await?;
-        let mut response = Response::from_wreq(resp, self.body_stall_timeout()).await?;
+        let mut response = Response::from_wreq(resp).await?;
 
         // Cookie warmup: if we get a challenge page, visit the homepage first
         // to collect Akamai cookies (_abck, bm_sz, etc.), then retry.
@@ -574,7 +530,7 @@ impl FetchClient {
             debug!("challenge detected, warming cookies via {homepage}");
             let _ = self.fetch(&homepage).await;
             let resp = client.get(url).send().await?;
-            response = Response::from_wreq(resp, self.body_stall_timeout()).await?;
+            response = Response::from_wreq(resp).await?;
             debug!("retried after cookie warmup: status={}", response.status());
         }
 
@@ -944,41 +900,6 @@ async fn collect_ordered<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn client_with_timeout(secs: u64) -> FetchClient {
-        FetchClient::new(FetchConfig {
-            timeout: Duration::from_secs(secs),
-            ..Default::default()
-        })
-        .expect("build client")
-    }
-
-    #[test]
-    fn body_stall_timeout_tracks_the_configured_timeout() {
-        assert_eq!(
-            client_with_timeout(10).body_stall_timeout(),
-            Duration::from_secs(10)
-        );
-        assert_eq!(
-            client_with_timeout(3).body_stall_timeout(),
-            Duration::from_secs(3)
-        );
-    }
-
-    /// The stall window is an IDLE timeout, not a total-body deadline: it must
-    /// not depend on how long the request has already been running, or a large
-    /// healthy download gets killed for being large.
-    #[tokio::test]
-    async fn body_stall_timeout_is_independent_of_elapsed_time() {
-        let c = client_with_timeout(5);
-        let before = c.body_stall_timeout();
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        assert_eq!(
-            before,
-            c.body_stall_timeout(),
-            "idle window must not shrink as the request ages"
-        );
-    }
 
     #[test]
     fn test_batch_result_struct() {

--- a/crates/webclaw-fetch/src/client.rs
+++ b/crates/webclaw-fetch/src/client.rs
@@ -85,7 +85,9 @@ struct Response {
     status: u16,
     url: String,
     headers: http::HeaderMap,
-    body: bytes::Bytes,
+    /// Owned as `Vec<u8>` rather than `Bytes` so `into_text` can hand the
+    /// allocation straight to `String` instead of copying it (see `into_text`).
+    body: Vec<u8>,
 }
 
 /// Maximum fetched body size. A single 50 MB HTML document is already
@@ -134,7 +136,8 @@ impl Response {
         // wreq 6.0.0-rc.29 dropped `Response::chunk()`. Stream post-decompression
         // bytes via `bytes_stream()` and keep enforcing the running ceiling so a
         // compression bomb is aborted before it is fully buffered in memory.
-        let mut buf = bytes::BytesMut::new();
+        // No capacity hint on purpose — see `into_text` and the note below.
+        let mut buf: Vec<u8> = Vec::new();
         let mut stream = resp.bytes_stream();
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(|e| FetchError::BodyDecode(e.to_string()))?;
@@ -146,7 +149,7 @@ impl Response {
             status,
             url,
             headers,
-            body: buf.freeze(),
+            body: buf,
         })
     }
 
@@ -167,15 +170,32 @@ impl Response {
         String::from_utf8_lossy(&self.body)
     }
 
+    /// Decode the body to `String`, consuming the buffer.
+    ///
+    /// The valid-UTF-8 case — effectively every page — takes ownership of the
+    /// existing allocation, so this costs no allocation and no copy.
+    /// `from_utf8_lossy(&self.body).into_owned()` always allocated a second
+    /// full-size buffer and memcpy'd the whole body into it.
+    ///
+    /// The fallback must decode `e.as_bytes()`, i.e. the bytes handed back by
+    /// the failed conversion, so invalid-UTF-8 output stays byte-identical to
+    /// the previous implementation. Do NOT add `shrink_to_fit()` — it would
+    /// reintroduce exactly the copy this removes.
+    ///
+    /// Charset handling is unchanged and still ignores `Content-Type: charset`;
+    /// a page in a non-UTF-8 encoding produces the same mojibake it did before.
+    /// Fixing that is separate work with extraction-quality blast radius.
     fn into_text(self) -> String {
-        String::from_utf8_lossy(&self.body).into_owned()
+        String::from_utf8(self.body)
+            .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
     }
 
     /// Consume the response and return the raw, undecoded body bytes.
     /// Used by [`FetchClient::fetch_raw`] for binary payloads (e.g. gzipped
     /// sitemaps) that must not be run through lossy UTF-8 decoding.
     fn into_body(self) -> bytes::Bytes {
-        self.body
+        // `Bytes::from(Vec<u8>)` adopts the allocation; still no copy.
+        bytes::Bytes::from(self.body)
     }
 }
 
@@ -537,9 +557,11 @@ impl FetchClient {
         let status = response.status();
         let final_url = response.url().to_string();
 
-        let headers = response.headers().clone();
+        // Borrowed, not cloned: both consumers below take `&HeaderMap`, and the
+        // borrow ends before `response` is moved into `into_text()`.
+        let headers = response.headers();
 
-        let is_pdf = is_pdf_content_type(&headers);
+        let is_pdf = is_pdf_content_type(headers);
 
         if is_pdf {
             debug!(status, "detected PDF response, using pdf extraction");
@@ -557,7 +579,7 @@ impl FetchClient {
             let pdf_result = webclaw_pdf::extract_pdf(bytes, self.pdf_mode.clone())?;
             Ok(pdf_to_extraction_result(&pdf_result, &final_url))
         } else if let Some(doc_type) =
-            crate::document::is_document_content_type(&headers, &final_url)
+            crate::document::is_document_content_type(headers, &final_url)
         {
             debug!(status, doc_type = ?doc_type, "detected document response, extracting");
 
@@ -900,6 +922,74 @@ async fn collect_ordered<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a `Response` around a raw body so the decode path can be tested
+    /// without a network round trip.
+    fn resp_with_body(body: Vec<u8>) -> Response {
+        Response {
+            status: 200,
+            url: "https://example.com/".to_string(),
+            headers: http::HeaderMap::new(),
+            body,
+        }
+    }
+
+    #[test]
+    fn into_text_matches_lossy_decoding_byte_for_byte() {
+        // `into_text` swapped `from_utf8_lossy(..).into_owned()` for a
+        // consuming `String::from_utf8`. The valid case must be identical and
+        // the INVALID case must still produce the same replacement characters
+        // in the same positions — that is the whole hazard of the change.
+        let mut cases: Vec<Vec<u8>> = vec![
+            b"".to_vec(),
+            b"plain ascii".to_vec(),
+            "héllo wörld — em dash".as_bytes().to_vec(),
+            "日本語のテキスト".as_bytes().to_vec(),
+            b"\xEF\xBB\xBFleading BOM".to_vec(),
+            b"truncated 2-byte: \xC3".to_vec(),
+            b"truncated 3-byte: \xE2\x82".to_vec(),
+            b"truncated 4-byte: \xF0\x9F\x98".to_vec(),
+            b"lone surrogate: \xED\xA0\x80".to_vec(),
+            b"overlong NUL: \xC0\x80".to_vec(),
+            b"beyond U+10FFFF: \xF5\x80\x80\x80".to_vec(),
+            b"windows-1252 quotes: \x93hi\x94".to_vec(),
+            vec![0xFF, 0xFE, 0xFD],
+        ];
+        // A bad byte at several offsets, including around common buffer edges.
+        for off in [0usize, 1, 4095, 4096, 4097, 65535] {
+            let mut v = vec![b'a'; 70_000];
+            v[off] = 0xFF;
+            cases.push(v);
+        }
+
+        for body in cases {
+            let expected = String::from_utf8_lossy(&body).into_owned();
+            let got = resp_with_body(body.clone()).into_text();
+            assert_eq!(
+                got,
+                expected,
+                "decode diverged for body prefix {:?}",
+                &body[..body.len().min(24)]
+            );
+        }
+    }
+
+    #[test]
+    fn into_text_reuses_the_buffer_for_valid_utf8() {
+        // The point of the change: no second allocation, no copy. Proven by
+        // the String landing on the same address the Vec occupied.
+        let body = "a reasonably sized valid utf-8 body".repeat(4096);
+        let bytes = body.into_bytes();
+        let ptr = bytes.as_ptr();
+        let text = resp_with_body(bytes).into_text();
+        assert_eq!(text.as_ptr(), ptr, "valid UTF-8 must not be re-allocated");
+    }
+
+    #[test]
+    fn into_body_still_returns_the_bytes_unchanged() {
+        let raw = vec![0x1f, 0x8b, 0x08, 0x00, 0xff, 0xfe];
+        assert_eq!(resp_with_body(raw.clone()).into_body().as_ref(), &raw[..]);
+    }
 
     #[test]
     fn test_batch_result_struct() {

--- a/crates/webclaw-fetch/src/client.rs
+++ b/crates/webclaw-fetch/src/client.rs
@@ -32,7 +32,31 @@ pub struct FetchConfig {
     /// random browser fingerprint. Same-host URLs reuse the same client
     /// for HTTP/2 connection multiplexing.
     pub proxy_pool: Vec<String>,
+    /// Per-attempt timeout handed to the HTTP client.
+    ///
+    /// NOTE: the underlying client applies this as two independent budgets —
+    /// one for the response head, then a *fresh* one for the body — so a single
+    /// attempt can take up to `2 * timeout`. Use [`total_timeout`](Self::total_timeout)
+    /// to bound the whole operation.
     pub timeout: Duration,
+    /// Ceiling on one complete `fetch`, covering every attempt, redirect and
+    /// body read.
+    ///
+    /// Without this the budget compounds and nothing states the real worst
+    /// case: `timeout` is applied twice per attempt by the client, and the
+    /// retry loop runs two attempts with a 1s pause, so a `timeout` of 12s
+    /// permits 49s. Callers reasonably read `timeout: 12s` as "this returns in
+    /// about 12 seconds"; a request that occupies a worker for 49s is a
+    /// reliability problem, not a slow page.
+    ///
+    /// Defaults to `2 * timeout`: one attempt keeps its full head+body budget,
+    /// so a slow-but-successful fetch is unaffected, while a retry can no
+    /// longer extend past it. Retries exist for transient failures, which fail
+    /// fast; retrying after a full-budget timeout rarely succeeds and always
+    /// costs the caller another full budget.
+    ///
+    /// `None` restores the old compounding behaviour.
+    pub total_timeout: Option<Duration>,
     pub follow_redirects: bool,
     pub max_redirects: u32,
     pub headers: HashMap<String, String>,
@@ -46,6 +70,7 @@ impl Default for FetchConfig {
             proxy: None,
             proxy_pool: Vec::new(),
             timeout: Duration::from_secs(12),
+            total_timeout: Some(Duration::from_secs(24)),
             follow_redirects: true,
             max_redirects: 10,
             headers: HashMap::from([("Accept-Language".to_string(), "en-US,en;q=0.9".to_string())]),
@@ -227,9 +252,43 @@ pub struct FetchClient {
     /// out. Stored as `Arc` so cloning a `FetchClient` (common in
     /// axum state) doesn't clone the underlying reqwest pool.
     cloud: Option<std::sync::Arc<crate::cloud::CloudClient>>,
+    /// Ceiling on one complete `fetch`. See [`FetchConfig::total_timeout`].
+    total_timeout: Option<Duration>,
 }
 
 impl FetchClient {
+    /// Run one attempt under the remaining share of the total budget.
+    ///
+    /// Returns `Err(Timeout)` if the budget is already spent, so the caller
+    /// stops retrying rather than starting an attempt it cannot finish.
+    async fn within_budget<F, T>(
+        &self,
+        started: Instant,
+        url: &str,
+        attempt: F,
+    ) -> Result<T, FetchError>
+    where
+        F: std::future::Future<Output = Result<T, FetchError>>,
+    {
+        let Some(total) = self.total_timeout else {
+            return attempt.await;
+        };
+        let remaining = total.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            return Err(FetchError::Build(format!(
+                "fetch budget of {}ms exhausted for {url}",
+                total.as_millis()
+            )));
+        }
+        match tokio::time::timeout(remaining, attempt).await {
+            Ok(res) => res,
+            Err(_) => Err(FetchError::Build(format!(
+                "fetch exceeded its {}ms budget for {url}",
+                total.as_millis()
+            ))),
+        }
+    }
+
     /// Build a new client from config.
     pub fn new(config: FetchConfig) -> Result<Self, FetchError> {
         let variants = collect_variants(&config.browser);
@@ -288,6 +347,7 @@ impl FetchClient {
             pool,
             pdf_mode,
             cloud: None,
+            total_timeout: config.total_timeout,
         })
     }
 
@@ -361,13 +421,16 @@ impl FetchClient {
     pub async fn fetch(&self, url: &str) -> Result<FetchResult, FetchError> {
         let delays = [Duration::ZERO, Duration::from_secs(1)];
         let mut last_err = None;
+        // Clock starts before the first attempt so the retry pause and every
+        // attempt come out of one budget, rather than each getting a fresh one.
+        let started = Instant::now();
 
         for (attempt, delay) in delays.iter().enumerate() {
             if attempt > 0 {
                 tokio::time::sleep(*delay).await;
             }
 
-            match self.fetch_once(url).await {
+            match self.within_budget(started, url, self.fetch_once(url)).await {
                 Ok(result) => {
                     if is_retryable_status(result.status) && attempt < delays.len() - 1 {
                         warn!(
@@ -445,12 +508,17 @@ impl FetchClient {
     ) -> Result<FetchResult, FetchError> {
         let delays = [Duration::ZERO, Duration::from_secs(1)];
         let mut last_err = None;
+        // One budget across the whole call — see `within_budget`.
+        let started = Instant::now();
 
         for (attempt, delay) in delays.iter().enumerate() {
             if attempt > 0 {
                 tokio::time::sleep(*delay).await;
             }
-            match self.fetch_once_with_headers(url, extra).await {
+            match self
+                .within_budget(started, url, self.fetch_once_with_headers(url, extra))
+                .await
+            {
                 Ok(result) => {
                     if is_retryable_status(result.status) && attempt < delays.len() - 1 {
                         warn!(
@@ -932,6 +1000,83 @@ mod tests {
             headers: http::HeaderMap::new(),
             body,
         }
+    }
+
+    #[test]
+    fn total_timeout_defaults_to_twice_the_per_attempt_timeout() {
+        // The client applies `timeout` twice per attempt (head, then a fresh
+        // one for the body), so 2x keeps a single slow-but-successful fetch
+        // intact while stopping the retry loop from compounding it.
+        let c = FetchConfig::default();
+        assert_eq!(c.timeout, Duration::from_secs(12));
+        assert_eq!(c.total_timeout, Some(Duration::from_secs(24)));
+    }
+
+    #[tokio::test]
+    async fn within_budget_refuses_an_attempt_once_the_budget_is_spent() {
+        let client = FetchClient::new(FetchConfig {
+            total_timeout: Some(Duration::from_millis(50)),
+            ..Default::default()
+        })
+        .expect("build client");
+
+        // Pretend the call started long ago: the next attempt must not run.
+        let started = Instant::now() - Duration::from_secs(5);
+        let ran = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let ran2 = std::sync::Arc::clone(&ran);
+        let res: Result<(), FetchError> = client
+            .within_budget(started, "https://example.com", async move {
+                ran2.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            })
+            .await;
+
+        assert!(
+            res.is_err(),
+            "an exhausted budget must not start an attempt"
+        );
+        assert!(
+            !ran.load(std::sync::atomic::Ordering::SeqCst),
+            "the attempt future must never be polled once the budget is gone"
+        );
+    }
+
+    #[tokio::test]
+    async fn within_budget_bounds_a_hanging_attempt() {
+        let client = FetchClient::new(FetchConfig {
+            total_timeout: Some(Duration::from_millis(80)),
+            ..Default::default()
+        })
+        .expect("build client");
+
+        let began = Instant::now();
+        let res: Result<(), FetchError> = client
+            .within_budget(Instant::now(), "https://example.com", async {
+                // Far longer than the budget.
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Ok(())
+            })
+            .await;
+
+        assert!(res.is_err());
+        assert!(
+            began.elapsed() < Duration::from_secs(2),
+            "must abort at the budget, not run to completion"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_total_timeout_restores_uncapped_behaviour() {
+        let client = FetchClient::new(FetchConfig {
+            total_timeout: None,
+            ..Default::default()
+        })
+        .expect("build client");
+        let started = Instant::now() - Duration::from_secs(600);
+        let res: Result<u8, FetchError> = client
+            .within_budget(started, "https://example.com", async { Ok(7) })
+            .await;
+        assert_eq!(res.expect("should run"), 7);
     }
 
     #[test]

--- a/crates/webclaw-fetch/src/crawler.rs
+++ b/crates/webclaw-fetch/src/crawler.rs
@@ -32,8 +32,15 @@ pub struct CrawlConfig {
     pub fetch: FetchConfig,
     /// How deep to follow links. 1 = only immediate links from seed page.
     pub max_depth: usize,
-    /// Hard cap on total pages fetched (including the seed).
-    pub max_pages: usize,
+    /// Cap on total pages fetched (including the seed). `None` = no cap:
+    /// crawl until the frontier is exhausted, cancelled, or the caller stops
+    /// consuming.
+    ///
+    /// A page cap is a *policy* choice — quota, budget, patience — and belongs
+    /// to whoever is paying for the crawl, not to the engine. Callers that need
+    /// one set it; callers that want the whole site pass `None`. Pair `None`
+    /// with [`stream_only`](Self::stream_only) so memory stays flat.
+    pub max_pages: Option<usize>,
     /// Max concurrent in-flight requests.
     pub concurrency: usize,
     /// Minimum delay before each request (politeness).
@@ -84,7 +91,7 @@ impl Default for CrawlConfig {
         Self {
             fetch: FetchConfig::default(),
             max_depth: 1,
-            max_pages: 50,
+            max_pages: Some(50),
             concurrency: 5,
             delay: Duration::from_millis(100),
             path_prefix: None,
@@ -147,7 +154,23 @@ pub struct Crawler {
     seed_root_domain: String,
 }
 
+/// Frontier ceiling used when [`CrawlConfig::max_pages`] is `None`.
+///
+/// Not a page limit — see the frontier-trim comment in `crawl`. At roughly
+/// 100 bytes per queued URL this is on the order of 50 MB of pending
+/// frontier, which is the point at which holding more queued work costs more
+/// than it is worth.
+const UNCAPPED_FRONTIER_LIMIT: usize = 500_000;
+
 impl Crawler {
+    /// Whether the crawl may fetch another page.
+    ///
+    /// `None` means no cap, so this is always true and the crawl ends when the
+    /// frontier empties or the caller cancels.
+    fn under_page_cap(&self, completed: usize) -> bool {
+        self.config.max_pages.is_none_or(|max| completed < max)
+    }
+
     /// Build a new crawler from a seed URL and config.
     /// Constructs the underlying `FetchClient` from `config.fetch`.
     pub fn new(seed_url: &str, config: CrawlConfig) -> Result<Self, FetchError> {
@@ -307,7 +330,7 @@ impl Crawler {
             }
         }
 
-        while !frontier.is_empty() && completed < self.config.max_pages {
+        while !frontier.is_empty() && self.under_page_cap(completed) {
             // Check cancel flag before processing each batch
             if self.is_cancelled() {
                 info!("crawl cancelled by user");
@@ -318,7 +341,11 @@ impl Crawler {
             let batch: Vec<(String, usize)> = frontier
                 .drain(..)
                 .filter(|(url, _)| visited.insert(url.clone()))
-                .take(self.config.max_pages.saturating_sub(completed))
+                .take(
+                    self.config
+                        .max_pages
+                        .map_or(usize::MAX, |m| m.saturating_sub(completed)),
+                )
                 .collect();
 
             if batch.is_empty() {
@@ -434,7 +461,7 @@ impl Crawler {
                     (None, false) => pages.push(page),
                 }
 
-                if completed >= self.config.max_pages {
+                if !self.under_page_cap(completed) {
                     break;
                 }
 
@@ -445,17 +472,26 @@ impl Crawler {
                 }
             }
 
-            // Cap frontier size independently of max_pages. Pages like
-            // search-result listings or tag clouds can emit thousands of
-            // links per page; without this a single dense page could push
-            // the frontier into the tens of thousands of entries and keep
-            // String allocations alive even after max_pages halts crawling.
-            // Trim aggressively once we exceed 10× max_pages, keeping the
-            // most recently discovered entries which are still on-topic
-            // (breadth-first = siblings of the last page we saw).
-            let frontier_cap = self.config.max_pages.saturating_mul(10).max(100);
+            // Bound the frontier. This is a MEMORY rail, not a page limit:
+            // it caps queued-but-unfetched URLs, which are owned Strings held
+            // live for the whole crawl. Search-result listings, tag clouds and
+            // faceted navigation emit thousands of links per page, and a
+            // calendar-style URL space is effectively infinite — so this has to
+            // hold even when there is no page cap, or an uncapped crawl grows
+            // the frontier without limit and dies on memory rather than on
+            // work. Keeps the most recently discovered entries, which
+            // breadth-first means siblings of the last page seen.
+            let (frontier_cap, keep) = match self.config.max_pages {
+                Some(max) => (
+                    max.saturating_mul(10).max(100),
+                    max.saturating_mul(5).max(50),
+                ),
+                // Uncapped: a fixed ceiling, sized so a genuinely large site
+                // crawls without truncation while a link explosion still cannot
+                // grow unbounded.
+                None => (UNCAPPED_FRONTIER_LIMIT, UNCAPPED_FRONTIER_LIMIT / 2),
+            };
             if next_frontier.len() > frontier_cap {
-                let keep = self.config.max_pages.saturating_mul(5).max(50);
                 warn!(
                     frontier = next_frontier.len(),
                     cap = frontier_cap,
@@ -739,6 +775,42 @@ mod tests {
     use super::*;
 
     #[test]
+    fn no_page_cap_is_expressible_and_never_halts_the_crawl() {
+        // The whole point of `Option`: `None` must mean "keep going", not
+        // "stop at zero". A regression here would silently turn an uncapped
+        // crawl into a no-op.
+        let uncapped = Crawler::new(
+            "https://example.com/",
+            CrawlConfig {
+                max_pages: None,
+                ..Default::default()
+            },
+        )
+        .expect("build crawler");
+        assert!(uncapped.under_page_cap(0));
+        assert!(uncapped.under_page_cap(1_000_000));
+
+        let capped = Crawler::new(
+            "https://example.com/",
+            CrawlConfig {
+                max_pages: Some(3),
+                ..Default::default()
+            },
+        )
+        .expect("build crawler");
+        assert!(capped.under_page_cap(2));
+        assert!(!capped.under_page_cap(3));
+        assert!(!capped.under_page_cap(4));
+    }
+
+    #[test]
+    fn default_config_keeps_a_page_cap() {
+        // Uncapped has to be opt-in: a caller who says nothing should not get
+        // an unbounded crawl by accident.
+        assert_eq!(CrawlConfig::default().max_pages, Some(50));
+    }
+
+    #[test]
     fn stream_only_defaults_off_so_existing_callers_keep_collecting() {
         assert!(
             !CrawlConfig::default().stream_only,
@@ -753,7 +825,7 @@ mod tests {
     #[tokio::test]
     async fn failed_seed_is_counted_not_just_collected() {
         let cfg = CrawlConfig {
-            max_pages: 5,
+            max_pages: Some(5),
             ..Default::default()
         };
         let crawler = Crawler::new("https://invalid.invalid/", cfg).expect("build crawler");

--- a/crates/webclaw-fetch/src/crawler.rs
+++ b/crates/webclaw-fetch/src/crawler.rs
@@ -60,6 +60,23 @@ pub struct CrawlConfig {
     /// When set to `true`, the crawler breaks out of the main loop early.
     /// Callers (e.g. a Ctrl+C handler) can flip this to request graceful cancellation.
     pub cancel_flag: Option<Arc<AtomicBool>>,
+    /// Drop each `PageResult` after reporting it instead of collecting it into
+    /// [`CrawlResult::pages`].
+    ///
+    /// This is what makes a large crawl possible at all. Retention is O(pages ×
+    /// page size), and an extracted page runs to ~90 KB, so a 5 000-page crawl
+    /// holds roughly 440 MB and a 50 000-page crawl roughly 4.4 GB — the crawl
+    /// only returns once it is finished, so that is all live at once. The page
+    /// ceiling exists to bound that, not because the crawl itself cannot go
+    /// further.
+    ///
+    /// Set this with [`progress_tx`](Self::progress_tx) to stream results to
+    /// the consumer as they complete and keep peak memory flat regardless of
+    /// page count. `total`/`ok`/`errors` are still counted, so the summary is
+    /// unaffected; only `pages` comes back empty.
+    ///
+    /// Defaults to `false`, so existing callers keep collecting.
+    pub stream_only: bool,
 }
 
 impl Default for CrawlConfig {
@@ -78,6 +95,7 @@ impl Default for CrawlConfig {
             allow_external_links: false,
             progress_tx: None,
             cancel_flag: None,
+            stream_only: false,
         }
     }
 }
@@ -240,6 +258,11 @@ impl Crawler {
         let semaphore = Arc::new(Semaphore::new(self.config.concurrency));
         let mut visited: HashSet<String>;
         let mut pages: Vec<PageResult> = Vec::new();
+        // Counted independently of `pages`: in stream-only mode nothing is
+        // retained, so `pages.len()` can no longer stand in for progress.
+        let mut completed: usize = 0;
+        let mut ok_count: usize = 0;
+        let mut err_count: usize = 0;
         let mut frontier: Vec<(String, usize)>;
 
         // Resume from saved state or start fresh
@@ -284,7 +307,7 @@ impl Crawler {
             }
         }
 
-        while !frontier.is_empty() && pages.len() < self.config.max_pages {
+        while !frontier.is_empty() && completed < self.config.max_pages {
             // Check cancel flag before processing each batch
             if self.is_cancelled() {
                 info!("crawl cancelled by user");
@@ -295,7 +318,7 @@ impl Crawler {
             let batch: Vec<(String, usize)> = frontier
                 .drain(..)
                 .filter(|(url, _)| visited.insert(url.clone()))
-                .take(self.config.max_pages.saturating_sub(pages.len()))
+                .take(self.config.max_pages.saturating_sub(completed))
                 .collect();
 
             if batch.is_empty() {
@@ -388,14 +411,30 @@ impl Crawler {
                     }
                 }
 
-                // Stream progress if a channel is configured
-                if let Some(tx) = &self.config.progress_tx {
-                    let _ = tx.send(page.clone());
+                completed += 1;
+                if page.extraction.is_some() {
+                    ok_count += 1;
+                } else {
+                    err_count += 1;
                 }
 
-                pages.push(page);
+                // Stream progress if a channel is configured. In stream-only
+                // mode the page is moved into the channel rather than cloned —
+                // nothing downstream retains it, so the clone would be pure
+                // waste at exactly the page counts this mode exists to serve.
+                match (&self.config.progress_tx, self.config.stream_only) {
+                    (Some(tx), true) => {
+                        let _ = tx.send(page);
+                    }
+                    (Some(tx), false) => {
+                        let _ = tx.send(page.clone());
+                        pages.push(page);
+                    }
+                    (None, true) => {}
+                    (None, false) => pages.push(page),
+                }
 
-                if pages.len() >= self.config.max_pages {
+                if completed >= self.config.max_pages {
                     break;
                 }
 
@@ -430,10 +469,8 @@ impl Crawler {
         }
 
         let total_elapsed = start.elapsed();
-        let ok_count = pages.iter().filter(|p| p.extraction.is_some()).count();
-        let err_count = pages.len() - ok_count;
         info!(
-            total = pages.len(),
+            total = completed,
             ok = ok_count,
             errors = err_count,
             elapsed_ms = %total_elapsed.as_millis(),
@@ -441,7 +478,7 @@ impl Crawler {
         );
 
         CrawlResult {
-            total: pages.len(),
+            total: completed,
             ok: ok_count,
             errors: err_count,
             elapsed_secs: total_elapsed.as_secs_f64(),
@@ -700,6 +737,37 @@ fn glob_match_inner(pat: &[u8], text: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stream_only_defaults_off_so_existing_callers_keep_collecting() {
+        assert!(
+            !CrawlConfig::default().stream_only,
+            "flipping this default would silently empty CrawlResult::pages for every caller"
+        );
+    }
+
+    /// The seed-fetch failure path is the one place a `CrawlResult` is built
+    /// without running the main loop, so it is reachable without a network.
+    /// It must report the failure in the counters either way — those are what
+    /// a streaming consumer has left once `pages` is empty.
+    #[tokio::test]
+    async fn failed_seed_is_counted_not_just_collected() {
+        let cfg = CrawlConfig {
+            max_pages: 5,
+            ..Default::default()
+        };
+        let crawler = Crawler::new("https://invalid.invalid/", cfg).expect("build crawler");
+        let res = crawler.crawl("https://invalid.invalid/", None).await;
+
+        assert_eq!(res.total, 1);
+        assert_eq!(res.ok, 0);
+        assert_eq!(res.errors, 1);
+        assert_eq!(
+            res.total,
+            res.ok + res.errors,
+            "counters must reconcile independently of what `pages` retained"
+        );
+    }
 
     #[test]
     fn normalize_strips_fragment() {

--- a/crates/webclaw-fetch/src/map.rs
+++ b/crates/webclaw-fetch/src/map.rs
@@ -101,7 +101,7 @@ pub async fn discover_urls(
     let config = CrawlConfig {
         fetch: FetchConfig::default(),
         max_depth: opts.crawl_depth,
-        max_pages: opts.max_crawl_pages,
+        max_pages: Some(opts.max_crawl_pages),
         // Politeness + scope: same-origin only (crawler default), modest delay.
         delay: Duration::from_millis(50),
         ..CrawlConfig::default()

--- a/crates/webclaw-fetch/src/tls.rs
+++ b/crates/webclaw-fetch/src/tls.rs
@@ -541,7 +541,17 @@ pub fn build_client(
         .timeout(timeout)
         .connect_timeout(Duration::from_secs(5))
         .pool_idle_timeout(Duration::from_secs(90))
-        .pool_max_idle_per_host(8)
+        // wreq's default here is `usize::MAX`, so any value we set REMOVES
+        // pooling capacity rather than adding it. At 8, a crawl running 20
+        // concurrent requests against an HTTP/1.1 origin pools 8 connections
+        // and closes the other 12 as they are released — a 60% reconnect rate
+        // in steady state, each costing a fresh TCP + TLS handshake. HTTP/2
+        // origins are unaffected (one shared pool entry per key).
+        //
+        // Kept bounded rather than removed: `BrowserProfile::Random` builds six
+        // clients, each with its own pool, so an unbounded per-host cap is
+        // really a 6x cap. 32 covers realistic crawl concurrency with headroom.
+        .pool_max_idle_per_host(32)
         .tcp_keepalive(Duration::from_secs(60));
 
     if let Some(proxy_url) = proxy {

--- a/crates/webclaw-mcp/src/server.rs
+++ b/crates/webclaw-mcp/src/server.rs
@@ -268,7 +268,12 @@ impl WebclawMcp {
 
         let config = webclaw_fetch::CrawlConfig {
             max_depth: params.depth.unwrap_or(2) as usize,
-            max_pages: params.max_pages.unwrap_or(50),
+            // 0 = no cap; omitted keeps the modest default.
+            max_pages: match params.max_pages {
+                Some(0) => None,
+                Some(n) => Some(n),
+                None => Some(50),
+            },
             concurrency: params.concurrency.unwrap_or(5),
             use_sitemap: params.use_sitemap.unwrap_or(false),
             ..Default::default()

--- a/crates/webclaw-server/Cargo.toml
+++ b/crates/webclaw-server/Cargo.toml
@@ -22,6 +22,8 @@ tower-http     = { version = "0.6", features = ["trace", "cors"] }
 clap           = { workspace = true, features = ["derive", "env"] }
 serde          = { workspace = true }
 serde_json     = { workspace = true }
+# Streaming NDJSON batch responses (StreamExt::map over the fetch stream).
+futures-util   = "0.3"
 tracing        = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 anyhow         = "1"

--- a/crates/webclaw-server/src/routes/batch.rs
+++ b/crates/webclaw-server/src/routes/batch.rs
@@ -94,11 +94,11 @@ pub async fn batch(
                 Ok::<_, std::convert::Infallible>(line)
             });
 
-        return Ok(Response::builder()
+        return Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "application/x-ndjson")
             .body(Body::from_stream(lines))
-            .map_err(|e| ApiError::internal(format!("failed to start stream: {e}")))?);
+            .map_err(|e| ApiError::internal(format!("failed to start stream: {e}")));
     }
 
     let url_refs: Vec<&str> = safe_urls.iter().map(|s| s.as_str()).collect();

--- a/crates/webclaw-server/src/routes/batch.rs
+++ b/crates/webclaw-server/src/routes/batch.rs
@@ -1,17 +1,32 @@
 //! POST /v1/batch — fetch + extract many URLs in parallel.
 //!
-//! `concurrency` is hard-capped at 20 to avoid hammering targets and
-//! to bound memory growth for naive callers. For larger batches use
-//! the hosted API.
+//! There is no maximum batch size. There used to be one because the aggregate
+//! response is built entirely in memory before anything is sent, so a large
+//! batch had to be refused to stop the process growing with the request. That
+//! is a property of the *response shape*, not a sensible policy, and capping
+//! the count only moved the failure somewhere less obvious.
+//!
+//! Set `"stream": true` to get NDJSON instead: one JSON object per line,
+//! written as each URL completes. Nothing accumulates server-side, so batch
+//! size stops mattering and the caller sees progress instead of waiting for
+//! the whole set. Results arrive in completion order.
+//!
+//! `concurrency` is still bounded — that one is politeness toward the sites
+//! being fetched, not a limit on the caller.
 
+use axum::body::Body;
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use axum::{Json, extract::State};
+use futures_util::StreamExt;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use webclaw_core::ExtractionOptions;
 
 use crate::{error::ApiError, state::AppState};
 
-const HARD_MAX_URLS: usize = 100;
+/// Ceiling on in-flight requests. Politeness toward target sites, not a cap
+/// on how many URLs a caller may submit.
 const HARD_MAX_CONCURRENCY: usize = 20;
 
 #[derive(Debug, Deserialize, Default)]
@@ -19,6 +34,9 @@ const HARD_MAX_CONCURRENCY: usize = 20;
 pub struct BatchRequest {
     pub urls: Vec<String>,
     pub concurrency: Option<usize>,
+    /// Stream NDJSON (one result per line, in completion order) instead of
+    /// buffering the whole batch into a single JSON response.
+    pub stream: bool,
     pub include_selectors: Vec<String>,
     pub exclude_selectors: Vec<String>,
     pub only_main_content: bool,
@@ -27,15 +45,9 @@ pub struct BatchRequest {
 pub async fn batch(
     State(state): State<AppState>,
     Json(req): Json<BatchRequest>,
-) -> Result<Json<Value>, ApiError> {
+) -> Result<Response, ApiError> {
     if req.urls.is_empty() {
         return Err(ApiError::bad_request("`urls` is required"));
-    }
-    if req.urls.len() > HARD_MAX_URLS {
-        return Err(ApiError::bad_request(format!(
-            "too many urls: {} (max {HARD_MAX_URLS})",
-            req.urls.len()
-        )));
     }
     let mut safe_urls = Vec::with_capacity(req.urls.len());
     for url in &req.urls {
@@ -54,6 +66,40 @@ pub async fn batch(
         only_main_content: req.only_main_content,
         include_raw_html: false,
     };
+
+    if req.stream {
+        // Nothing is collected: each result is serialised and flushed as it
+        // lands, so memory is flat regardless of how many URLs were submitted.
+        // The stream outlives this handler, so it owns its own client handle
+        // rather than borrowing from `state`.
+        let client = std::sync::Arc::clone(state.fetch());
+        let lines = client
+            .fetch_and_extract_batch_stream(safe_urls, concurrency, options)
+            .map(|r| {
+                let value = match r.result {
+                    Ok(extraction) => json!({
+                        "url": r.url,
+                        "ok": true,
+                        "metadata": extraction.metadata,
+                        "markdown": extraction.content.markdown,
+                    }),
+                    Err(e) => json!({ "url": r.url, "ok": false, "error": e.to_string() }),
+                };
+                // A serialisation failure must not kill the stream mid-batch;
+                // emit a parseable error line for that URL and keep going.
+                let mut line = serde_json::to_string(&value).unwrap_or_else(|e| {
+                    json!({ "ok": false, "error": format!("serialize failed: {e}") }).to_string()
+                });
+                line.push('\n');
+                Ok::<_, std::convert::Infallible>(line)
+            });
+
+        return Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/x-ndjson")
+            .body(Body::from_stream(lines))
+            .map_err(|e| ApiError::internal(format!("failed to start stream: {e}")))?);
+    }
 
     let url_refs: Vec<&str> = safe_urls.iter().map(|s| s.as_str()).collect();
     let results = state
@@ -89,5 +135,6 @@ pub async fn batch(
         "completed": ok,
         "errors": errors,
         "results": out,
-    })))
+    }))
+    .into_response())
 }

--- a/crates/webclaw-server/src/routes/crawl.rs
+++ b/crates/webclaw-server/src/routes/crawl.rs
@@ -1,7 +1,7 @@
 //! POST /v1/crawl — synchronous BFS crawl.
 //!
 //! NOTE: this server is stateless — there is no job queue. Crawls run
-//! inline and return when complete. `max_pages` is hard-capped at 500
+//! inline and return when complete. `max_pages` is the caller's choice;
 //! to avoid OOM on naive callers. For large crawls + async jobs, use
 //! the hosted API at api.webclaw.io.
 
@@ -12,8 +12,6 @@ use std::time::Duration;
 use webclaw_fetch::{CrawlConfig, Crawler, FetchConfig};
 
 use crate::{error::ApiError, state::AppState};
-
-const HARD_MAX_PAGES: usize = 500;
 
 #[derive(Debug, Deserialize, Default)]
 #[serde(default)]
@@ -37,11 +35,20 @@ pub async fn crawl(
         return Err(ApiError::bad_request("`url` is required"));
     }
     let url = webclaw_fetch::url_security::validate_public_http_url(&req.url).await?;
-    let max_pages = req.max_pages.unwrap_or(50).min(HARD_MAX_PAGES);
+    // No hard ceiling: a page cap is the caller's budget decision, not the
+    // server's. `0` requests an uncapped crawl; omitting it keeps a modest
+    // default so an unspecified request cannot run forever.
+    let max_pages = match req.max_pages {
+        Some(0) => None,
+        Some(n) => Some(n),
+        None => Some(50),
+    };
     let max_depth = req.max_depth.unwrap_or(3);
     let concurrency = req.concurrency.unwrap_or(5).min(20);
 
     let config = CrawlConfig {
+        // This route returns the whole result inline, so it collects.
+        stream_only: false,
         fetch: FetchConfig::default(),
         max_depth,
         max_pages,


### PR DESCRIPTION
Promotes `staging` to `main`. Contains PR #98 and PR #97, both merged to staging with CI green.

## #98 — uncapped crawl, streaming batch, one fetch budget

- **Crawl without a page limit.** `CrawlConfig.max_pages` is `Option<usize>`; `None` crawls until the site is exhausted. `--max-pages 0` on the CLI, `max_pages: 0` on the MCP tool and self-host server. Defaults unchanged, so a caller who says nothing still gets a bounded crawl.
- **Streaming batch.** `POST /v1/batch` with `"stream": true` answers NDJSON, one result per line as each URL finishes. Memory is flat regardless of batch size, and the maximum batch size is gone.
- **Crawl streaming mode.** `stream_only` drops each page after reporting it, so peak memory stays flat — this is what makes an unbounded crawl practical.
- **One time budget per fetch.** The client applied `timeout` twice per attempt and the retry loop ran two attempts, so a 12s timeout permitted 49s of wall clock. `total_timeout` now bounds the whole operation.
- **Response bodies no longer copied twice.** 500 KB pages 337 µs → 55 µs, 16 MB 5.3 ms → 1.5 ms, peak memory per in-flight fetch halved.
- **Chronopost parcel tracking extractor.**

## #97 — 0.6.17 reconcile

The MCP registry has advertised 0.6.17 since 2026-07-22, but no tag was ever cut, so `0.6.16` stayed the newest release while the registry pointed at a version that did not exist. This reconciles the repo and drops a competitor's name from the Chinese README so it matches the English one.

## Merge conflict, resolved

`CHANGELOG.md` conflicted: both sides inserted at the same point in `[Unreleased]`. #98 added a Performance entry, #97 added the released `[0.6.17]` section. Both were kept — the Performance note stays under `[Unreleased]` (not yet released) and `[0.6.17]` sits below it as a cut version. Verified `cargo fmt --check --all` clean and 682 lib tests passing on the merged tree before pushing.

## Not tagged

`Cargo.toml` reads `0.6.17`, but the tag is deliberately **not** cut in this PR. Since #98 landed after the 0.6.17 notes were written, the next tag needs to contain it — so the release should be **v0.6.18**, decided separately.

This matters downstream: `webclaw-server` PR #31 currently pins core by *branch* (`branch = "feat/uncapped-crawl"`), which breaks the tag-pinning rule and cannot ship. It gets repinned once a tag exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)