### PR TITLE
chore(release): 0.6.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.6.18] - 2026-08-06
+
 ### Added
 - **Crawl without a page limit.** `CrawlConfig.max_pages` is now `Option<usize>`; `None` crawls until the site is exhausted or you cancel. Expose it as `--max-pages 0` on the CLI, `max_pages: 0` on the MCP `crawl` tool, and `max_pages: 0` on the self-host server, whose 500-page ceiling is gone. Defaults are unchanged, so a caller who says nothing still gets a bounded crawl.
 - **Streaming batch.** `POST /v1/batch` accepts `"stream": true` and answers with NDJSON — one result per line, written as each URL finishes — so a batch of ten and a batch of ten thousand cost the same in memory. The maximum batch size is gone with it. Backed by a new `FetchClient::fetch_and_extract_batch_stream`, which keeps at most `concurrency` fetches in flight instead of starting one task per URL up front.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-cli"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "clap",
  "dotenvy",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-core"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "ego-tree",
  "once_cell",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-fetch"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-llm"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-mcp"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "dirs",
  "dotenvy",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-pdf"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "pdf-extract",
  "thiserror",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-server"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.6.17"
+version = "0.6.18"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/0xMassi/webclaw"


### PR DESCRIPTION
Cuts a release containing everything under `[Unreleased]` since #98.

## Why 0.6.18 and not 0.6.17

The `[0.6.17]` section was written before #98 merged, so a 0.6.17 tag would contain **none** of the uncapped crawl, streaming batch, or one-fetch-budget work.

This matters downstream: `webclaw-server` staging currently pins core by commit SHA (`rev = "727b8c1"`) rather than a tag, because no tag containing that work existed. Its `Cargo.toml` comment says `tag = "vX.Y.Z"` before this reaches main. **This release is what unblocks that.**

## Contents

- Crawl without a page limit — `max_pages: Option<usize>`, defaults unchanged
- Streaming batch — NDJSON, flat memory regardless of batch size
- Crawl streaming mode — `stream_only`, what makes an unbounded crawl practical
- One time budget per fetch — a 12s timeout no longer permits 49s of wall clock
- Chronopost parcel tracking extractor
- CF false positives fixed — healthy Cloudflare-fronted pages no longer escalated
- Response bodies no longer copied twice — 500 KB 337 µs → 55 µs

## Verification

`cargo fmt --check --all` clean, 682 lib tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)