### PR TITLE
perf(sitemap): skip fallback probes when robots.txt declares sitemaps

### DIFF
--- a/crates/webclaw-fetch/src/sitemap.rs
+++ b/crates/webclaw-fetch/src/sitemap.rs
@@ -58,6 +58,24 @@ pub async fn discover(
     client: &FetchClient,
     base_url: &str,
 ) -> Result<Vec<SitemapEntry>, FetchError> {
+    discover_within(client, base_url, None).await
+}
+
+/// Like [`discover`], but stops walking once `budget` has elapsed and returns
+/// whatever was parsed so far.
+///
+/// Callers used to wrap `discover` in `tokio::time::timeout`. That cancels the
+/// future mid-walk and drops its local `entries` vec, so a site whose sitemaps
+/// were 90% parsed returned ZERO urls -- contiki.com discarded ~5,400 already-
+/// parsed entries this way on every call, which is also why its `url_index`
+/// row count sat at 14 instead of thousands. Checking the clock between fetches
+/// keeps the work.
+pub async fn discover_within(
+    client: &FetchClient,
+    base_url: &str,
+    budget: Option<std::time::Duration>,
+) -> Result<Vec<SitemapEntry>, FetchError> {
+    let deadline = budget.map(|b| std::time::Instant::now() + b);
     let base = base_url.trim_end_matches('/');
     let mut sitemap_urls: Vec<String> = Vec::new();
 
@@ -79,19 +97,36 @@ pub async fn discover(
         }
     }
 
-    // Step 2: Try common sitemap paths (skipping any already discovered via robots.txt)
-    for path in FALLBACK_SITEMAP_PATHS {
-        let candidate = format!("{base}{path}");
-        if !sitemap_urls.iter().any(|u| u == &candidate) {
-            sitemap_urls.push(candidate);
+    // Step 2: Guess common sitemap paths -- but only when robots.txt gave us
+    // nothing. The guesses are a fallback for sites that do not declare their
+    // sitemaps, and running them anyway costs real budget for no gain: on
+    // contiki.com, which declares 11 sitemaps in robots.txt, the 8 probes took
+    // 3 of the caller's 15 seconds and 5 of them 404'd or redirected. That is
+    // 20% of the budget spent re-discovering what robots.txt already said.
+    if sitemap_urls.is_empty() {
+        for path in FALLBACK_SITEMAP_PATHS {
+            sitemap_urls.push(format!("{base}{path}"));
         }
+    } else {
+        debug!(
+            count = sitemap_urls.len(),
+            "robots.txt declared sitemaps, skipping fallback path probes"
+        );
     }
 
     // Step 3: Fetch and parse each sitemap, handling indexes recursively
     let mut seen_urls: HashSet<String> = HashSet::new();
     let mut entries: Vec<SitemapEntry> = Vec::new();
 
-    fetch_sitemaps(client, &sitemap_urls, &mut entries, &mut seen_urls, 0).await;
+    fetch_sitemaps(
+        client,
+        &sitemap_urls,
+        &mut entries,
+        &mut seen_urls,
+        0,
+        deadline,
+    )
+    .await;
 
     debug!(total = entries.len(), "sitemap discovery complete");
     Ok(entries)
@@ -104,6 +139,7 @@ async fn fetch_sitemaps(
     entries: &mut Vec<SitemapEntry>,
     seen_urls: &mut HashSet<String>,
     depth: usize,
+    deadline: Option<std::time::Instant>,
 ) {
     if depth > MAX_RECURSION_DEPTH {
         warn!(depth, "sitemap recursion limit reached, stopping");
@@ -111,6 +147,15 @@ async fn fetch_sitemaps(
     }
 
     for sitemap_url in urls {
+        // Stop between fetches rather than being cancelled mid-flight, so
+        // everything parsed so far survives and reaches the caller.
+        if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+            debug!(
+                parsed = entries.len(),
+                depth, "sitemap budget spent, returning partial results"
+            );
+            return;
+        }
         debug!(url = %sitemap_url, depth, "fetching sitemap");
 
         // Fetch raw bytes so gzipped sitemaps survive intact. `fetch` runs
@@ -155,6 +200,7 @@ async fn fetch_sitemaps(
                     entries,
                     seen_urls,
                     depth + 1,
+                    deadline,
                 ))
                 .await;
             }


### PR DESCRIPTION
A site that lists its sitemaps in `robots.txt` still had 8 guessed paths probed on top. On `contiki.com` — which declares 11 — those probes cost **3s of a 15s budget** and 5 of them 404'd or redirected. 20% of the budget spent re-discovering what robots.txt already said, on a walk that then timed out and returned nothing.

Also adds `discover_within()`, which stops between fetches once a budget is spent and returns what it parsed. Callers previously wrapped `discover()` in `tokio::time::timeout`, which **cancels the future and drops its local `entries` vec** — so a walk that was 90% done returned **zero** URLs. That is why contiki's `url_index` row count sat at 14 instead of thousands: map saves what it returns, and it returned nothing.

## Measured — pinned proxy exit, interleaved arms, medians

| site | before | after | |
|---|---|---|---|
| contiki.com | 10.4s | **5.6s** | **1.9×** (5/5 pairs faster) |
| intrepidtravel.com | 4.5s | **2.8s** | **1.6×** (4/4 pairs faster) |
| heritage-expeditions.com | 13.0s | 13.7s | no change — **as designed** |

Heritage declares **0** sitemaps in robots.txt, so it still needs the fallback probes and the fix correctly does not apply.

**URL counts were identical in every arm** (8,904 / 34,081 / 3,258). Pure latency saved, no discovery lost.

## The pinning is the point

Unpinned, the **same unpatched binary** returned 2,285 / 17,033 / 12,176 URLs for intrepidtravel on three consecutive runs — a 7.5× spread with no code change. Different proxy exits reach different CDN edges with different content and rate-limit state.

I initially misread that noise as a regression in an earlier concurrency experiment and reverted work on that basis. Any future benchmark on this path needs a fixed exit or it measures the proxy pool, not the code.

## Not proven

`discover_within`'s partial-result path is **not exercised** by these runs — nothing timed out once the probes were skipped. It is strictly better than returning `Vec::new()`, but it is untested and I am not claiming otherwise.

## Verification

`cargo fmt --check --all`, `cargo clippy --all -- -D warnings`, 682 lib tests, and `wasm32` check with and without default features — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)