### PR TITLE
chore(release): 0.6.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.6.19] - 2026-08-10
+
+### Performance
+- **Sitemap discovery skips redundant probes.** A site that declares its sitemaps in `robots.txt` was still having 8 guessed paths probed on top, which cost real time for no gain: on one site declaring 11 sitemaps, the probes took 3 seconds of a 15-second budget and most of them 404'd. Discovery on such sites is now 1.6–1.9x faster with identical results. Sites that declare no sitemaps are unaffected and still use the fallback paths.
+- **Partial sitemap results survive a timeout.** A caller that bounded discovery with a deadline previously got nothing back when the deadline passed, discarding everything already parsed. `discover_within` now returns what it found.
+
 ## [0.6.18] - 2026-08-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-cli"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "clap",
  "dotenvy",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-core"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "ego-tree",
  "once_cell",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-fetch"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-llm"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-mcp"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "dirs",
  "dotenvy",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-pdf"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "pdf-extract",
  "thiserror",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-server"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.6.18"
+version = "0.6.19"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/0xMassi/webclaw"


### PR DESCRIPTION
Cuts the sitemap discovery work from #101 so `webclaw-server` can repin.

| site | before | after | |
|---|---|---|---|
| contiki.com | 10.4s | **5.6s** | **1.9×** |
| intrepidtravel.com | 4.5s | **2.8s** | **1.6×** |
| heritage-expeditions.com | 13.0s | 13.7s | unchanged (declares no sitemaps) |

URL counts identical in every arm — pure latency saved.

Consumers pin core by tag, so this work is unreachable downstream until a tag contains it. Server PR #37 repins to this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)