### PR TITLE
fix(mcp): reply -32601 to pre-handshake requests instead of exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **The MCP server no longer exits when a client speaks before the handshake.** A request sent ahead of `initialize` ended the process without a reply, so the client saw a closed pipe instead of an error. Newer MCP clients open a connection by asking the server which protocol era it supports, then fall back to the classic handshake on that same connection — a server that exits takes the connection with it, so the fallback never runs and the client cannot connect at all. Such requests are now answered with JSON-RPC `-32601`, the same answer an unknown method already gets once connected, and the connection stays up. Stray notifications before the handshake are ignored rather than fatal. Nothing is executed early, and clients that connect the classic way are unaffected.
+
 ## [0.6.19] - 2026-08-10
 
 ### Performance

--- a/crates/webclaw-mcp/src/handshake_guard.rs
+++ b/crates/webclaw-mcp/src/handshake_guard.rs
@@ -1,0 +1,406 @@
+//! Keeps the stdio server alive when a client speaks before the handshake.
+//!
+//! rmcp's server handshake reads messages in two windows, and each one treats
+//! anything it does not expect as fatal:
+//!
+//! 1. before `initialize` it tolerates only `ping`;
+//! 2. between `initialize` and `notifications/initialized` it tolerates only
+//!    `ping` and `logging/setLevel`.
+//!
+//! Anything else makes `serve()` return `ExpectedInitializeRequest` /
+//! `ExpectedInitializedNotification` **without writing a reply**, and the
+//! transport is dropped with it. On stdio that ends the process, so the client
+//! sees a closed pipe rather than an error it can act on.
+//!
+//! That became a real interop problem with MCP revision `2026-07-28`, whose
+//! SEP-2575 defines `server/discover` as a probe a dual-era client sends
+//! *before* `initialize` to find out which era it is talking to. The official
+//! Go and Python clients run that probe by default and then fall back to the
+//! legacy `initialize` handshake **on the same connection**. A server that
+//! exits during the probe takes the connection with it, so the fallback never
+//! runs and the client cannot connect at all (issue #107).
+//!
+//! Note the spec does not require a reply here: a legacy server that stays
+//! silent and lets the client time out is explicitly allowed. The problem is
+//! specifically that we *die*, which is neither a reply nor a timeout.
+//!
+//! This wrapper sits between rmcp and the real transport and answers those
+//! messages itself, so rmcp's state machine only ever sees what it expects:
+//!
+//! - a request rmcp would reject gets JSON-RPC `-32601`, matching what the
+//!   server already returns for an unknown method *after* the handshake;
+//! - a notification, response or error gets dropped, since JSON-RPC forbids
+//!   replying to those and dropping is enough to keep the handshake alive.
+//!
+//! The handshake rules stay strict: nothing is executed early, and rmcp still
+//! decides when the connection is initialized. Once it is, every message is
+//! passed straight through and rmcp's own dispatch answers unknown methods.
+//!
+//! This does not cover a malformed line. rmcp's codec maps a decode error to
+//! end-of-stream and the framed reader stays fused, so one bad line still ends
+//! the session before this wrapper can see it. That is a separate defect.
+
+use rmcp::model::{
+    ClientJsonRpcMessage, ClientNotification, ClientRequest, ErrorCode, ErrorData,
+    ServerJsonRpcMessage,
+};
+use rmcp::service::{RoleServer, RxJsonRpcMessage, TxJsonRpcMessage};
+use rmcp::transport::Transport;
+
+/// Which of rmcp's handshake windows we are in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    /// Before `initialize`. rmcp tolerates `ping` only.
+    AwaitingInitialize,
+    /// After `initialize`, before `notifications/initialized`.
+    /// rmcp tolerates `ping` and `logging/setLevel`.
+    AwaitingInitialized,
+    /// Handshake complete. rmcp handles everything from here.
+    Open,
+}
+
+/// Wraps a transport so pre-handshake traffic cannot kill the connection.
+pub struct PreHandshakeGuard<T> {
+    inner: T,
+    phase: Phase,
+}
+
+impl<T> PreHandshakeGuard<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            phase: Phase::AwaitingInitialize,
+        }
+    }
+}
+
+/// Is this message one rmcp will accept in the given window?
+///
+/// Mirrors rmcp's two handshake loops. Kept as a free function so the tests can
+/// assert on the classification without driving a transport.
+fn is_tolerated(msg: &ClientJsonRpcMessage, phase: Phase) -> bool {
+    if phase == Phase::Open {
+        return true;
+    }
+    match msg {
+        ClientJsonRpcMessage::Request(req) => matches!(
+            (&req.request, phase),
+            (ClientRequest::PingRequest(_), _)
+                | (
+                    ClientRequest::InitializeRequest(_),
+                    Phase::AwaitingInitialize
+                )
+                | (
+                    ClientRequest::SetLevelRequest(_),
+                    Phase::AwaitingInitialized
+                )
+        ),
+        ClientJsonRpcMessage::Notification(n) => {
+            phase == Phase::AwaitingInitialized
+                && matches!(
+                    n.notification,
+                    ClientNotification::InitializedNotification(_)
+                )
+        }
+        _ => false,
+    }
+}
+
+/// Advance the handshake state for a message we are about to pass through.
+fn advance(phase: Phase, msg: &ClientJsonRpcMessage) -> Phase {
+    match (phase, msg) {
+        (Phase::AwaitingInitialize, ClientJsonRpcMessage::Request(req))
+            if matches!(req.request, ClientRequest::InitializeRequest(_)) =>
+        {
+            Phase::AwaitingInitialized
+        }
+        (Phase::AwaitingInitialized, ClientJsonRpcMessage::Notification(n))
+            if matches!(
+                n.notification,
+                ClientNotification::InitializedNotification(_)
+            ) =>
+        {
+            Phase::Open
+        }
+        _ => phase,
+    }
+}
+
+impl<T> Transport<RoleServer> for PreHandshakeGuard<T>
+where
+    T: Transport<RoleServer>,
+{
+    type Error = T::Error;
+
+    fn send(
+        &mut self,
+        item: TxJsonRpcMessage<RoleServer>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        self.inner.send(item)
+    }
+
+    async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleServer>> {
+        loop {
+            let msg = self.inner.receive().await?;
+
+            if is_tolerated(&msg, self.phase) {
+                self.phase = advance(self.phase, &msg);
+                return Some(msg);
+            }
+
+            // rmcp would treat this as fatal. Answer it here instead.
+            match &msg {
+                ClientJsonRpcMessage::Request(req) => {
+                    let method = req.request.method().to_string();
+                    tracing::debug!(
+                        method = %method,
+                        phase = ?self.phase,
+                        "answering pre-handshake request with -32601"
+                    );
+                    let reply = ServerJsonRpcMessage::error(
+                        ErrorData::new(ErrorCode::METHOD_NOT_FOUND, method, None),
+                        req.id.clone(),
+                    );
+                    if let Err(e) = self.inner.send(reply).await {
+                        // The pipe is gone; the next receive reports EOF.
+                        tracing::debug!(error = %e, "failed to send -32601");
+                    }
+                }
+                // No reply is owed for these, and dropping them is what keeps
+                // the handshake alive.
+                other => tracing::debug!(
+                    phase = ?self.phase,
+                    "dropping unexpected pre-handshake message: {}",
+                    match other {
+                        ClientJsonRpcMessage::Notification(_) => "notification",
+                        ClientJsonRpcMessage::Response(_) => "response",
+                        ClientJsonRpcMessage::Error(_) => "error",
+                        ClientJsonRpcMessage::Request(_) => unreachable!("handled above"),
+                    }
+                ),
+            }
+        }
+    }
+
+    fn close(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.close()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    /// Replays a scripted client and records what the server wrote back.
+    struct MockTransport {
+        incoming: VecDeque<ClientJsonRpcMessage>,
+        sent: Arc<Mutex<Vec<ServerJsonRpcMessage>>>,
+    }
+
+    /// Hand-rolled so the test does not pull in an error-derive dependency.
+    #[derive(Debug)]
+    struct MockError;
+
+    impl std::fmt::Display for MockError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("mock transport error")
+        }
+    }
+
+    impl std::error::Error for MockError {}
+
+    impl MockTransport {
+        fn new(lines: &[&str]) -> (Self, Arc<Mutex<Vec<ServerJsonRpcMessage>>>) {
+            let sent = Arc::new(Mutex::new(Vec::new()));
+            let incoming = lines
+                .iter()
+                .map(|l| serde_json::from_str(l).expect("test message must parse"))
+                .collect();
+            (
+                Self {
+                    incoming,
+                    sent: sent.clone(),
+                },
+                sent,
+            )
+        }
+    }
+
+    impl Transport<RoleServer> for MockTransport {
+        type Error = MockError;
+
+        fn send(
+            &mut self,
+            item: TxJsonRpcMessage<RoleServer>,
+        ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+            let sent = self.sent.clone();
+            async move {
+                sent.lock().unwrap().push(item);
+                Ok(())
+            }
+        }
+
+        async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleServer>> {
+            self.incoming.pop_front()
+        }
+
+        async fn close(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    const INITIALIZE: &str = r#"{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"2025-06-18","clientInfo":{"name":"t","version":"1"},"capabilities":{}}}"#;
+    const INITIALIZED: &str = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+    const DISCOVER: &str = r#"{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}"#;
+
+    fn method_of(msg: &ClientJsonRpcMessage) -> Option<String> {
+        match msg {
+            ClientJsonRpcMessage::Request(r) => Some(r.request.method().to_string()),
+            _ => None,
+        }
+    }
+
+    /// The reported case: the probe must be answered, not fatal, and the
+    /// `initialize` behind it must still reach rmcp.
+    #[tokio::test]
+    async fn discover_before_initialize_is_answered_and_initialize_survives() {
+        let (mock, sent) = MockTransport::new(&[DISCOVER, INITIALIZE, INITIALIZED]);
+        let mut guard = PreHandshakeGuard::new(mock);
+
+        let first = guard.receive().await.expect("initialize must be delivered");
+        assert_eq!(method_of(&first).as_deref(), Some("initialize"));
+
+        let second = guard
+            .receive()
+            .await
+            .expect("initialized must be delivered");
+        assert!(matches!(second, ClientJsonRpcMessage::Notification(_)));
+
+        let sent = sent.lock().unwrap();
+        assert_eq!(sent.len(), 1, "exactly one reply, for the probe");
+        let json = serde_json::to_value(&sent[0]).unwrap();
+        assert_eq!(json["error"]["code"], -32601);
+        assert_eq!(json["error"]["message"], "server/discover");
+        assert_eq!(json["id"], 1, "reply must carry the probe's id");
+    }
+
+    /// A known method before `initialize` is fatal to rmcp too, so the guard
+    /// must not special-case `server/discover`.
+    #[tokio::test]
+    async fn any_unexpected_pre_handshake_request_is_answered() {
+        let (mock, sent) = MockTransport::new(&[
+            r#"{"jsonrpc":"2.0","id":7,"method":"tools/list","params":{}}"#,
+            INITIALIZE,
+        ]);
+        let mut guard = PreHandshakeGuard::new(mock);
+
+        let first = guard.receive().await.expect("initialize must be delivered");
+        assert_eq!(method_of(&first).as_deref(), Some("initialize"));
+
+        let sent = sent.lock().unwrap();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(
+            serde_json::to_value(&sent[0]).unwrap()["error"]["code"],
+            -32601
+        );
+    }
+
+    /// rmcp answers pre-init `ping` itself, so the guard must pass it through
+    /// untouched rather than shadowing it with an error.
+    #[tokio::test]
+    async fn ping_is_passed_through_untouched() {
+        let (mock, sent) =
+            MockTransport::new(&[r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#, INITIALIZE]);
+        let mut guard = PreHandshakeGuard::new(mock);
+
+        let first = guard.receive().await.expect("ping must reach rmcp");
+        assert_eq!(method_of(&first).as_deref(), Some("ping"));
+        assert!(
+            sent.lock().unwrap().is_empty(),
+            "guard must not reply to ping"
+        );
+    }
+
+    /// JSON-RPC forbids replying to a notification, and rmcp treats an
+    /// unexpected one as fatal, so it has to be dropped silently.
+    #[tokio::test]
+    async fn unexpected_notification_is_dropped_without_a_reply() {
+        let (mock, sent) = MockTransport::new(&[
+            r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1}}"#,
+            INITIALIZE,
+        ]);
+        let mut guard = PreHandshakeGuard::new(mock);
+
+        let first = guard.receive().await.expect("initialize must be delivered");
+        assert_eq!(method_of(&first).as_deref(), Some("initialize"));
+        assert!(sent.lock().unwrap().is_empty());
+    }
+
+    /// `notifications/initialized` is only meaningful after `initialize`.
+    /// Honouring it earlier would open the guard and hand rmcp a message its
+    /// first window rejects, reintroducing the crash this module prevents.
+    #[tokio::test]
+    async fn initialized_before_initialize_does_not_open_the_guard() {
+        let (mock, _sent) = MockTransport::new(&[
+            INITIALIZED,
+            r#"{"jsonrpc":"2.0","id":9,"method":"tools/list","params":{}}"#,
+            INITIALIZE,
+        ]);
+        let mut guard = PreHandshakeGuard::new(mock);
+
+        // The stray notification is dropped and `tools/list` is still
+        // intercepted, proving the guard did not move to Open.
+        let first = guard.receive().await.expect("initialize must be delivered");
+        assert_eq!(method_of(&first).as_deref(), Some("initialize"));
+    }
+
+    /// Between `initialize` and `initialized`, rmcp tolerates `logging/setLevel`
+    /// (VS Code sends it there) but nothing else.
+    #[tokio::test]
+    async fn set_level_passes_only_in_the_second_window() {
+        let set_level =
+            r#"{"jsonrpc":"2.0","id":3,"method":"logging/setLevel","params":{"level":"info"}}"#;
+
+        // Before `initialize`: not tolerated, so it is answered.
+        let (mock, sent) = MockTransport::new(&[set_level, INITIALIZE]);
+        let mut guard = PreHandshakeGuard::new(mock);
+        let first = guard.receive().await.unwrap();
+        assert_eq!(method_of(&first).as_deref(), Some("initialize"));
+        assert_eq!(sent.lock().unwrap().len(), 1);
+
+        // After `initialize`: tolerated, so it passes through.
+        let (mock, sent) = MockTransport::new(&[INITIALIZE, set_level]);
+        let mut guard = PreHandshakeGuard::new(mock);
+        let _init = guard.receive().await.unwrap();
+        let second = guard.receive().await.unwrap();
+        assert_eq!(method_of(&second).as_deref(), Some("logging/setLevel"));
+        assert!(sent.lock().unwrap().is_empty());
+    }
+
+    /// After the handshake, rmcp's own dispatch answers unknown methods, so the
+    /// guard must stop intercepting or it would shadow real responses.
+    #[tokio::test]
+    async fn guard_stops_intercepting_once_open() {
+        let (mock, sent) = MockTransport::new(&[INITIALIZE, INITIALIZED, DISCOVER]);
+        let mut guard = PreHandshakeGuard::new(mock);
+
+        let _init = guard.receive().await.unwrap();
+        let _initialized = guard.receive().await.unwrap();
+        let third = guard.receive().await.expect("must reach rmcp once open");
+        assert_eq!(method_of(&third).as_deref(), Some("server/discover"));
+        assert!(
+            sent.lock().unwrap().is_empty(),
+            "rmcp answers this after the handshake, not the guard"
+        );
+    }
+
+    /// End of stream must still terminate the loop rather than spin.
+    #[tokio::test]
+    async fn eof_returns_none() {
+        let (mock, _sent) = MockTransport::new(&[DISCOVER]);
+        let mut guard = PreHandshakeGuard::new(mock);
+        assert!(guard.receive().await.is_none());
+    }
+}

--- a/crates/webclaw-mcp/src/main.rs
+++ b/crates/webclaw-mcp/src/main.rs
@@ -1,12 +1,15 @@
 /// webclaw-mcp: MCP (Model Context Protocol) server for webclaw.
 /// Exposes web extraction tools over stdio transport for AI agents
 /// like Claude Desktop, Claude Code, and other MCP clients.
+mod handshake_guard;
 mod server;
 mod tools;
 
 use rmcp::ServiceExt;
-use rmcp::transport::stdio;
+use rmcp::service::RoleServer;
+use rmcp::transport::async_rw::AsyncRwTransport;
 
+use handshake_guard::PreHandshakeGuard;
 use server::WebclawMcp;
 
 #[tokio::main]
@@ -20,7 +23,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_ansi(false)
         .init();
 
-    let service = WebclawMcp::new().await.serve(stdio()).await?;
+    // Built explicitly rather than via `stdio()` so the handshake guard can wrap
+    // a concrete transport; see handshake_guard for why it is needed.
+    let transport = PreHandshakeGuard::new(AsyncRwTransport::<RoleServer, _, _>::new_server(
+        tokio::io::stdin(),
+        tokio::io::stdout(),
+    ));
+
+    let service = WebclawMcp::new().await.serve(transport).await?;
 
     service.waiting().await?;
     Ok(())


### PR DESCRIPTION
Fixes #107.

## The problem

A request sent before `initialize` made the stdio server exit with **no reply at all**. The client got a closed pipe rather than an error it could act on.

That breaks connection for clients on MCP revision `2026-07-28`. SEP-2575 defines `server/discover` as an era probe a dual-era client sends before `initialize`, and the official Go and Python clients run it by default, then fall back to the classic handshake **on the same connection**. A server that exits during the probe takes the connection with it, so the fallback has nothing to run on.

## What this does

A transport wrapper between rmcp and stdio. It mirrors rmcp's two handshake windows and answers what rmcp would treat as fatal:

| window | rmcp tolerates | guard does |
|---|---|---|
| before `initialize` | `ping` | requests → `-32601`, notifications dropped |
| `initialize` → `initialized` | `ping`, `logging/setLevel` | same |
| after `initialized` | everything | passes straight through |

`-32601` is what an unknown method already gets once connected, so the answer is consistent either side of the handshake. Notifications and responses are dropped because JSON-RPC forbids replying to them, and dropping is enough to keep the connection alive.

**Scoped to the handshake window, not to `server/discover`.** `tools/list` and stray notifications hit the same fatal path, so keying on the method name would have left them broken.

## Verification

A zero-config **Go SDK v1.7.0** client, before and after:

```
before: CONNECT FAILED — connection closed: calling "initialize": client is closing: EOF
after:  CONNECT OK: protocol=2025-06-18 server=webclaw-mcp 0.6.19 / tools: 14
```

**Python SDK v2.0.0** in its default `auto` mode: `CONNECT FAILED` → `CONNECT OK (tools=14)`.

Raw stdio, probe then handshake, both pipelined in one write and with delays between messages:

```
{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"server/discover"}}
{"jsonrpc":"2.0","id":2,"result":{"protocolVersion":"2025-06-18",...}}
{"jsonrpc":"2.0","id":3,"result":{"tools":[...14 tools...]}}
```

8 new unit tests cover both windows, pass-through of `ping` and `logging/setLevel`, and that the guard stops intercepting once open. One asserts that `notifications/initialized` arriving *before* `initialize` does not open the guard, which would otherwise hand rmcp a message its first window rejects and reintroduce the crash.

Full CI locally: `fmt --check`, `clippy --all -- -D warnings`, `test --workspace --lib`, `test -p webclaw-mcp`, `test -p webclaw-cli`, `doc --no-deps --workspace`, and both wasm32 checks.

## Notes

**No dependency change.** The fix uses rmcp's public `Transport` trait, already available through the `transport-io` feature. Bumping rmcp would not have helped: 1.x and 2.x share the identical fatal path, and 3.0.0's stateless dispatch only answers probes carrying the full SEP-2575 `_meta` key set, so a probe missing `io.modelcontextprotocol/clientCapabilities` still dies.

**The spec does not require a reply here.** A legacy server that stays silent and lets the client time out is explicitly allowed, and the fallback "MUST NOT be keyed to one specific error code". The defect is that the process *dies*, which is neither a reply nor a timeout. Worth stating so the rationale is not recorded as a conformance fix.

**Not covered:** a malformed line is still fatal. rmcp's codec maps a decode error to end-of-stream and the framed reader stays fused, so it never reaches this wrapper. Separate defect, tracked on its own.
