### PR TITLE
chore(release): 0.6.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.6.20] - 2026-08-16
+
 ### Fixed
 - **The MCP server no longer exits when a client speaks before the handshake.** A request sent ahead of `initialize` ended the process without a reply, so the client saw a closed pipe instead of an error. Newer MCP clients open a connection by asking the server which protocol era it supports, then fall back to the classic handshake on that same connection — a server that exits takes the connection with it, so the fallback never runs and the client cannot connect at all. Such requests are now answered with JSON-RPC `-32601`, the same answer an unknown method already gets once connected, and the connection stays up. Stray notifications before the handshake are ignored rather than fatal. Nothing is executed early, and clients that connect the classic way are unaffected.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-cli"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "clap",
  "dotenvy",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-core"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "ego-tree",
  "once_cell",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-fetch"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-llm"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-mcp"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "dirs",
  "dotenvy",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-pdf"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "pdf-extract",
  "thiserror",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-server"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.6.19"
+version = "0.6.20"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/0xMassi/webclaw"


### PR DESCRIPTION
Version bump only, no code changes.

Ships the MCP stdio handshake fix from #108 (closing #107). Until there is a tagged release the fix is unreachable for affected users: `npx @webclaw/mcp` installs a prebuilt binary pinned to the latest tag.

Cut on its own rather than waiting for #105, which adds `#[non_exhaustive]` to a public enum and is therefore a breaking release.

- `[workspace.package]` version 0.6.19 → 0.6.20, inherited by all 7 crates
- `Cargo.lock` regenerated
- CHANGELOG `Unreleased` entry becomes `[0.6.20] - 2026-08-16`

`packages/create-webclaw` and `@webclaw/mcp` need no manual bump: the release workflow's npm job pins the launcher to the new tag and publishes the next patch above whatever is on npm.

After merge, pushing `v0.6.20` triggers the release workflow (binaries → GitHub release → npm, Docker, Homebrew).