### PR TITLE
fix(mcp): upgrade rmcp to 3.1 so an unreadable line no longer ends the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **A single unreadable line no longer ends an MCP session.** One line the server could not parse, including a blank line, ended the connection and was reported as if the client had hung up — even when a perfectly valid request followed on the next line. Bad lines are now skipped and the session continues. A batched request, which the server does not accept, now answers with an explicit error instead of closing.
+
+### Changed
+- **The MCP server now speaks the current protocol revision (2026-07-28) with clients that ask for it.** Clients that negotiate an older revision are unaffected and continue to work exactly as before.
+
 ## [0.6.20] - 2026-08-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -237,7 +237,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -245,6 +245,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bindgen"
@@ -261,7 +267,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -419,10 +425,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -478,7 +482,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -622,14 +626,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -637,26 +641,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -688,7 +692,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -699,7 +703,7 @@ checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -742,7 +746,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -883,7 +887,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -983,7 +987,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1250,7 +1254,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1631,7 +1635,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1758,7 +1762,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1867,7 +1871,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1940,7 +1944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2150,7 +2154,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2188,7 +2192,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -2236,12 +2240,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.3.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
- "async-trait",
- "base64",
+ "base64 0.23.1",
  "chrono",
  "futures",
  "pastey",
@@ -2254,19 +2257,20 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "1.3.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2385,7 +2389,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2461,7 +2465,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2472,7 +2476,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2651,6 +2655,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,7 +2682,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2711,7 +2726,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2814,7 +2829,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2912,7 +2927,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2986,7 +3001,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3064,6 +3079,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -3152,7 +3178,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3417,7 +3443,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3428,7 +3454,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3641,7 +3667,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3657,7 +3683,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3811,7 +3837,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3832,7 +3858,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3852,7 +3878,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3873,7 +3899,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3906,7 +3932,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/webclaw-mcp/Cargo.toml
+++ b/crates/webclaw-mcp/Cargo.toml
@@ -14,7 +14,7 @@ webclaw-core = { workspace = true }
 webclaw-fetch = { workspace = true }
 webclaw-llm = { workspace = true }
 webclaw-pdf = { workspace = true }
-rmcp = { version = "1.2", features = ["server", "macros", "transport-io", "schemars"] }
+rmcp = { version = "3.1", features = ["server", "macros", "transport-io", "schemars"] }
 schemars = "1.0"
 dotenvy = { workspace = true }
 serde = { workspace = true }

--- a/crates/webclaw-mcp/src/handshake_guard.rs
+++ b/crates/webclaw-mcp/src/handshake_guard.rs
@@ -36,13 +36,20 @@
 //! decides when the connection is initialized. Once it is, every message is
 //! passed straight through and rmcp's own dispatch answers unknown methods.
 //!
-//! This does not cover a malformed line. rmcp's codec maps a decode error to
-//! end-of-stream and the framed reader stays fused, so one bad line still ends
-//! the session before this wrapper can see it. That is a separate defect.
+//! One case is deliberately NOT answered here. rmcp serves a pre-`initialize`
+//! request statelessly when it carries every `_meta` key 2026-07-28 requires,
+//! and answering such a probe ourselves would tell a modern client we are a
+//! legacy server and cost it the newer protocol. `is_stateless_request` mirrors
+//! rmcp's own gate so those reach rmcp untouched; only the probes rmcp would
+//! die on are absorbed.
+//!
+//! A line the codec cannot decode is handled by rmcp itself since 1.7.0, which
+//! skips the bad frame and keeps reading rather than reporting end-of-stream
+//! (issue #109). This wrapper sits above the codec and never sees those.
 
 use rmcp::model::{
-    ClientJsonRpcMessage, ClientNotification, ClientRequest, ErrorCode, ErrorData,
-    ServerJsonRpcMessage,
+    ClientJsonRpcMessage, ClientNotification, ClientRequest, ErrorCode, ErrorData, GetMeta,
+    ProtocolVersion, ServerJsonRpcMessage,
 };
 use rmcp::service::{RoleServer, RxJsonRpcMessage, TxJsonRpcMessage};
 use rmcp::transport::Transport;
@@ -83,6 +90,15 @@ fn is_tolerated(msg: &ClientJsonRpcMessage, phase: Phase) -> bool {
         return true;
     }
     match msg {
+        // rmcp serves a request carrying the full 2026-07-28 `_meta` set
+        // statelessly, without an `initialize` first. Passing those through is
+        // what lets a modern client negotiate 2026-07-28 instead of falling
+        // back to the legacy handshake, so the guard must not answer them.
+        ClientJsonRpcMessage::Request(req)
+            if phase == Phase::AwaitingInitialize && is_stateless_request(&req.request) =>
+        {
+            true
+        }
         ClientJsonRpcMessage::Request(req) => matches!(
             (&req.request, phase),
             (ClientRequest::PingRequest(_), _)
@@ -104,6 +120,20 @@ fn is_tolerated(msg: &ClientJsonRpcMessage, phase: Phase) -> bool {
         }
         _ => false,
     }
+}
+
+/// Can rmcp serve this request without an `initialize` first?
+///
+/// Mirrors rmcp's own gate: a pre-`initialize` request is dispatched
+/// statelessly only when it carries every `_meta` key the 2026-07-28 revision
+/// requires. A request missing any of them takes rmcp's fatal path instead,
+/// which is the case this guard exists to absorb.
+fn is_stateless_request(request: &ClientRequest) -> bool {
+    !matches!(request, ClientRequest::InitializeRequest(_))
+        && request
+            .get_meta()
+            .missing_required_keys(&ProtocolVersion::V_2026_07_28)
+            .is_empty()
 }
 
 /// Advance the handshake state for a message we are about to pass through.
@@ -159,7 +189,7 @@ where
                     );
                     let reply = ServerJsonRpcMessage::error(
                         ErrorData::new(ErrorCode::METHOD_NOT_FOUND, method, None),
-                        req.id.clone(),
+                        Some(req.id.clone()),
                     );
                     if let Err(e) = self.inner.send(reply).await {
                         // The pipe is gone; the next receive reports EOF.
@@ -254,6 +284,10 @@ mod tests {
     const INITIALIZE: &str = r#"{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"2025-06-18","clientInfo":{"name":"t","version":"1"},"capabilities":{}}}"#;
     const INITIALIZED: &str = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
     const DISCOVER: &str = r#"{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}"#;
+
+    /// A probe carrying the `_meta` keys 2026-07-28 requires. rmcp serves this
+    /// one itself, so the guard must not intercept it.
+    const DISCOVER_WITH_META: &str = r#"{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"#;
 
     fn method_of(msg: &ClientJsonRpcMessage) -> Option<String> {
         match msg {
@@ -394,6 +428,38 @@ mod tests {
             sent.lock().unwrap().is_empty(),
             "rmcp answers this after the handshake, not the guard"
         );
+    }
+
+    /// rmcp serves a fully-specified 2026-07-28 probe statelessly. Answering it
+    /// here would advertise us as a legacy server and cost a modern client the
+    /// newer protocol, so it has to reach rmcp untouched.
+    #[tokio::test]
+    async fn conformant_probe_is_passed_through_for_rmcp_to_serve() {
+        let (mock, sent) = MockTransport::new(&[DISCOVER_WITH_META]);
+        let mut guard = PreHandshakeGuard::new(mock);
+
+        let first = guard
+            .receive()
+            .await
+            .expect("a stateless-capable probe must reach rmcp");
+        assert_eq!(method_of(&first).as_deref(), Some("server/discover"));
+        assert!(
+            sent.lock().unwrap().is_empty(),
+            "rmcp answers this one, not the guard"
+        );
+    }
+
+    /// The same method WITHOUT the required `_meta` is the case rmcp dies on,
+    /// so it must still be absorbed. This is the pair that keeps both
+    /// behaviours honest.
+    #[tokio::test]
+    async fn probe_missing_required_meta_is_still_answered() {
+        let (mock, sent) = MockTransport::new(&[DISCOVER, INITIALIZE, INITIALIZED]);
+        let mut guard = PreHandshakeGuard::new(mock);
+
+        let first = guard.receive().await.expect("initialize must be delivered");
+        assert_eq!(method_of(&first).as_deref(), Some("initialize"));
+        assert_eq!(sent.lock().unwrap().len(), 1, "the bare probe was answered");
     }
 
     /// End of stream must still terminate the loop rather than spin.


### PR DESCRIPTION
Fixes #109.

## The problem

One line the codec could not decode ended the stdio session, reported as `ConnectionClosed` — the same value a clean EOF produces. A valid `initialize` on the next line was never seen.

rmcp 1.3 maps a codec `Err` to `None` (its end-of-stream value) while `FramedRead` stays fused after a decode error. The guard from #108 sits above the codec, so this was never fixable at our layer. Upstream fixed it in 1.7.0.

## Measured against the v0.6.20 binary

| input | v0.6.20 | this PR |
|---|---|---|
| malformed line, then valid handshake | exit 1, **0 bytes** | handshake completes |
| blank line, then valid handshake | exit 1, **0 bytes** | handshake completes |
| batched request | exit 1, **0 bytes** | `-32600 Invalid request` |

The blank-line case was not in the issue. A bare CRLF behaves the same way.

## Why 3.1 and not an in-range bump

`cargo update -p rmcp` lands **1.8.0**, which carries upstream regression #941: responses silently dropped under concurrent load. That trades one bug for a worse one.

## A protocol upgrade fell out of it

rmcp 3.x serves a pre-`initialize` request statelessly when it carries every `_meta` key 2026-07-28 requires. The guard was intercepting those with `-32601`, which tells a modern client we are legacy.

`is_stateless_request` now mirrors rmcp's own gate, so conformant probes reach rmcp untouched and only the ones rmcp would die on are absorbed. A real go-sdk v1.7.0 client:

```
before: CONNECT OK: protocol=2025-11-25
after:  CONNECT OK: protocol=2026-07-28
```

Both still list all 14 tools.

## #107 is unchanged

A bare probe with no `_meta` still gets `-32601` and the process stays up. Two new tests pin the pair: `conformant_probe_is_passed_through_for_rmcp_to_serve` and `probe_missing_required_meta_is_still_answered`.

## API break

One, absorbed here: `ServerJsonRpcMessage::error` now takes `Option<RequestId>`.

Full CI locally: fmt, clippy `-D warnings`, `test --workspace --lib`, `test -p webclaw-mcp` (53 pass), doc, and both wasm32 checks.