### PR TITLE
docs: finish the EmptyPdf wording sweep

### DIFF
--- a/crates/webclaw-cli/src/main.rs
+++ b/crates/webclaw-cli/src/main.rs
@@ -483,7 +483,7 @@ enum Browser {
 
 #[derive(Clone, ValueEnum, Default)]
 enum PdfModeArg {
-    /// Error if PDF has no extractable text (catches scanned PDFs)
+    /// Error if the PDF yields no non-whitespace text
     #[default]
     Auto,
     /// Return whatever text is found, even if empty

--- a/crates/webclaw-pdf/src/lib.rs
+++ b/crates/webclaw-pdf/src/lib.rs
@@ -14,7 +14,7 @@ use tracing::debug;
 /// Controls how strictly we treat empty/sparse PDFs.
 #[derive(Debug, Clone, Default)]
 pub enum PdfMode {
-    /// Try text extraction; error if no text found (catches scanned PDFs early).
+    /// Try text extraction; error if the result has no non-whitespace text.
     #[default]
     Auto,
     /// Return whatever text is found, even if empty. Caller decides what to do.

--- a/examples/README.md
+++ b/examples/README.md
@@ -117,7 +117,7 @@ webclaw --diff-with snapshot.json https://example.com
 webclaw https://example.com/report.pdf
 
 # Control PDF mode
-webclaw --pdf-mode auto https://example.com/report.pdf  # Error on empty (catches scanned PDFs)
+webclaw --pdf-mode auto https://example.com/report.pdf  # Error if no non-whitespace text
 webclaw --pdf-mode fast https://example.com/report.pdf  # Return whatever text is found
 ```
 


### PR DESCRIPTION
Completes the wording fix started in #111 (issue #106).

#106 was about a claim, not a comment. "Auto mode catches scanned PDFs" appeared in **five** places. #111 fixed two and closed the issue. This clears the other three.

The one that matters most is `PdfModeArg::Auto`, because clap renders that doc comment in `webclaw --help`:

```
  --pdf-mode <PDF_MODE>
      Possible values:
      - auto: Error if the PDF yields no non-whitespace text   ← was "(catches scanned PDFs)"
```

## Why the claim is worth chasing down

`EmptyPdf` fires only when the normalized text has zero non-whitespace characters. A scanned page carrying a page number or a footer stamp returns `Ok` with unusable text. An outside contributor built #104 and #105 on exactly this wording, which is what #106's "Why it matters" section was about.

## Changed

- `crates/webclaw-pdf/src/lib.rs` — `PdfMode::Auto` variant doc
- `crates/webclaw-cli/src/main.rs` — `PdfModeArg::Auto` variant doc (the `--help` one)
- `examples/README.md` — the `--pdf-mode auto` example comment

Behaviour untouched; every changed line is a comment.

Verified: grep for `catches scanned` / `scanned/image-only` / `Scanned PDFs return` across the repo now returns nothing.