### PR TITLE
chore(release): 0.6.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.6.21] - 2026-08-16
+
 ### Fixed
 - **A single unreadable line no longer ends an MCP session.** One line the server could not parse, including a blank line, ended the connection and was reported as if the client had hung up — even when a perfectly valid request followed on the next line. Bad lines are now skipped and the session continues. A batched request, which the server does not accept, now answers with an explicit error instead of closing.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-cli"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "clap",
  "dotenvy",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-core"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "ego-tree",
  "once_cell",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-fetch"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-llm"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-mcp"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "dirs",
  "dotenvy",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-pdf"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "pdf-extract",
  "thiserror",
@@ -3356,7 +3356,7 @@ dependencies = [
 
 [[package]]
 name = "webclaw-server"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.6.20"
+version = "0.6.21"
 edition = "2024"
 license = "AGPL-3.0"
 repository = "https://github.com/0xMassi/webclaw"

--- a/packages/create-webclaw/server.json
+++ b/packages/create-webclaw/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.0xMassi/webclaw",
   "title": "webclaw",
   "description": "Turn any URL into clean markdown/JSON for AI agents. Self-hostable web content extraction.",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@webclaw/mcp",
-      "version": "0.6.20",
+      "version": "0.6.21",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Version bump only, no code changes.

Ships the MCP stdio codec fix from #112 (closing #109). Until there is a tag the fix is unreachable: `npx @webclaw/mcp` installs a prebuilt binary pinned to the latest release.

- `[workspace.package]` 0.6.20 → 0.6.21, inherited by all 7 crates
- `Cargo.lock` regenerated
- CHANGELOG `Unreleased` → `[0.6.21] - 2026-08-16`
- `packages/create-webclaw/server.json` bumped in the same commit. #114 brought it current after four releases of drift; releasing without touching it would have made it stale again the same day.

What users get: a client that sends an unparseable or blank line keeps its session instead of being dropped, and a client on the current protocol revision negotiates 2026-07-28 rather than falling back.