### PR TITLE
feat: add OrcaRouter LLM provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **OrcaRouter provider in the LLM chain (opt-in).** Set `ORCAROUTER_API_KEY` to add [OrcaRouter](https://www.orcarouter.ai) as a provider for the LLM features (extraction, summarization). It's added at the end of the chain — Ollama → OpenAI → Gemini → Anthropic → Atlas Cloud → OrcaRouter — so it only runs when you configure it and never preempts an already-configured provider. Override the model with `ORCAROUTER_MODEL` (default `orcarouter/auto`) and the endpoint with `ORCAROUTER_BASE_URL` (default `https://api.orcarouter.ai/v1`).
+
 ## [0.6.21] - 2026-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ webclaw/
 | `OPENAI_BASE_URL` | OpenAI-compatible base URL |
 | `ANTHROPIC_API_KEY` | Anthropic-compatible LLM provider key |
 | `ANTHROPIC_BASE_URL` | Anthropic-compatible base URL |
+| `ORCAROUTER_API_KEY` | OrcaRouter LLM provider key |
+| `ORCAROUTER_BASE_URL` | OrcaRouter base URL (defaults to https://api.orcarouter.ai/v1) |
 | `WEBCLAW_PROXY` | Single proxy URL |
 | `WEBCLAW_PROXY_FILE` | Proxy pool file |
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -362,6 +362,8 @@ webclaw/
 | `OPENAI_BASE_URL` | 兼容 OpenAI 的接口地址 |
 | `ANTHROPIC_API_KEY` | 兼容 Anthropic 的 LLM 提供方密钥 |
 | `ANTHROPIC_BASE_URL` | 兼容 Anthropic 的接口地址 |
+| `ORCAROUTER_API_KEY` | OrcaRouter LLM 提供方密钥 |
+| `ORCAROUTER_BASE_URL` | OrcaRouter 接口地址（默认 https://api.orcarouter.ai/v1） |
 | `WEBCLAW_PROXY` | 单个代理 URL |
 | `WEBCLAW_PROXY_FILE` | 代理池文件 |
 

--- a/crates/webclaw-cli/src/main.rs
+++ b/crates/webclaw-cli/src/main.rs
@@ -339,7 +339,7 @@ struct Cli {
     #[arg(long, num_args = 0..=1, default_missing_value = "3")]
     summarize: Option<usize>,
 
-    /// Force a specific LLM provider (ollama, openai, atlascloud, anthropic)
+    /// Force a specific LLM provider (ollama, openai, atlascloud, anthropic, orcarouter)
     #[arg(long, env = "WEBCLAW_LLM_PROVIDER")]
     llm_provider: Option<String>,
 
@@ -2266,6 +2266,15 @@ async fn build_llm_provider(cli: &Cli) -> Result<Box<dyn LlmProvider>, String> {
                 .ok_or("ATLASCLOUD_API_KEY not set")?;
                 Ok(Box::new(provider))
             }
+            "orcarouter" => {
+                let provider = webclaw_llm::providers::orcarouter::OrcaRouterProvider::new(
+                    None,
+                    cli.llm_base_url.clone(),
+                    cli.llm_model.clone(),
+                )
+                .ok_or("ORCAROUTER_API_KEY not set")?;
+                Ok(Box::new(provider))
+            }
             "anthropic" => {
                 let provider = webclaw_llm::providers::anthropic::AnthropicProvider::with_base_url(
                     None,
@@ -2276,14 +2285,14 @@ async fn build_llm_provider(cli: &Cli) -> Result<Box<dyn LlmProvider>, String> {
                 Ok(Box::new(provider))
             }
             other => Err(format!(
-                "unknown LLM provider: {other} (use ollama, openai, atlascloud, or anthropic)"
+                "unknown LLM provider: {other} (use ollama, openai, atlascloud, anthropic, or orcarouter)"
             )),
         }
     } else {
         let chain = webclaw_llm::ProviderChain::default().await;
         if chain.is_empty() {
             return Err(
-                "no LLM providers available -- start Ollama or set OPENAI_API_KEY / ANTHROPIC_API_KEY"
+                "no LLM providers available -- start Ollama or set OPENAI_API_KEY / ANTHROPIC_API_KEY / ORCAROUTER_API_KEY"
                     .into(),
             );
         }

--- a/crates/webclaw-llm/src/chain.rs
+++ b/crates/webclaw-llm/src/chain.rs
@@ -8,7 +8,7 @@ use crate::error::LlmError;
 use crate::provider::{CompletionRequest, LlmProvider};
 use crate::providers::{
     anthropic::AnthropicProvider, atlascloud::AtlasCloudProvider, gemini::GeminiProvider,
-    ollama::OllamaProvider, openai::OpenAiProvider,
+    ollama::OllamaProvider, openai::OpenAiProvider, orcarouter::OrcaRouterProvider,
 };
 
 pub struct ProviderChain {
@@ -16,13 +16,14 @@ pub struct ProviderChain {
 }
 
 impl ProviderChain {
-    /// Build the default chain: Ollama -> OpenAI -> Gemini -> Anthropic -> Atlas Cloud.
+    /// Build the default chain: Ollama -> OpenAI -> Gemini -> Anthropic -> Atlas Cloud -> OrcaRouter.
     /// Ollama is always added (availability checked at call time).
     /// Cloud providers are only added if their API keys are configured.
     /// Gemini sits ahead of Anthropic so Google Cloud credits are preferred,
     /// with Anthropic as the last-resort fallback. Atlas Cloud is opt-in and
     /// added last (only when `ATLASCLOUD_API_KEY` is set), so it never preempts
-    /// an already-configured provider.
+    /// an already-configured provider. OrcaRouter is also opt-in and added last,
+    /// only when `ORCAROUTER_API_KEY` is set.
     pub async fn default() -> Self {
         let mut providers: Vec<Box<dyn LlmProvider>> = Vec::new();
 
@@ -52,6 +53,11 @@ impl ProviderChain {
         if let Some(atlas) = AtlasCloudProvider::new(None, None, None) {
             debug!("atlascloud configured, adding to chain");
             providers.push(Box::new(atlas));
+        }
+
+        if let Some(orcarouter) = OrcaRouterProvider::new(None, None, None) {
+            debug!("orcarouter configured, adding to chain");
+            providers.push(Box::new(orcarouter));
         }
 
         Self { providers }

--- a/crates/webclaw-llm/src/providers/mod.rs
+++ b/crates/webclaw-llm/src/providers/mod.rs
@@ -3,6 +3,7 @@ pub mod atlascloud;
 pub mod gemini;
 pub mod ollama;
 pub mod openai;
+pub mod orcarouter;
 
 use crate::error::LlmError;
 

--- a/crates/webclaw-llm/src/providers/orcarouter.rs
+++ b/crates/webclaw-llm/src/providers/orcarouter.rs
@@ -1,0 +1,78 @@
+/// OrcaRouter provider — OpenAI-compatible chat completions with OrcaRouter defaults.
+use async_trait::async_trait;
+
+use crate::error::LlmError;
+use crate::provider::{CompletionRequest, LlmProvider};
+
+use super::openai::OpenAiProvider;
+
+pub struct OrcaRouterProvider {
+    inner: OpenAiProvider,
+}
+
+impl OrcaRouterProvider {
+    /// Returns `None` if no OrcaRouter API key is available (param or env).
+    pub fn new(
+        key_override: Option<String>,
+        base_url: Option<String>,
+        model: Option<String>,
+    ) -> Option<Self> {
+        let key = super::load_api_key(key_override, "ORCAROUTER_API_KEY")?;
+        let base_url = base_url
+            .or_else(|| std::env::var("ORCAROUTER_BASE_URL").ok())
+            .unwrap_or_else(|| "https://api.orcarouter.ai/v1".into());
+        let model = model
+            .or_else(|| std::env::var("ORCAROUTER_MODEL").ok())
+            .unwrap_or_else(|| "orcarouter/auto".into());
+        let inner = OpenAiProvider::new(Some(key), Some(base_url), Some(model))?;
+        Some(Self { inner })
+    }
+
+    pub fn default_model(&self) -> &str {
+        self.inner.default_model()
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OrcaRouterProvider {
+    async fn complete(&self, request: &CompletionRequest) -> Result<String, LlmError> {
+        self.inner.complete(request).await
+    }
+
+    async fn is_available(&self) -> bool {
+        self.inner.is_available().await
+    }
+
+    fn name(&self) -> &str {
+        "orcarouter"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_key_returns_none() {
+        assert!(OrcaRouterProvider::new(Some(String::new()), None, None).is_none());
+    }
+
+    #[test]
+    fn explicit_key_constructs_with_orcarouter_defaults() {
+        let provider =
+            OrcaRouterProvider::new(Some("test-key".into()), None, None).expect("should construct");
+        assert_eq!(provider.name(), "orcarouter");
+        assert_eq!(provider.default_model(), "orcarouter/auto");
+    }
+
+    #[test]
+    fn explicit_model_override() {
+        let provider = OrcaRouterProvider::new(
+            Some("test-key".into()),
+            Some("https://proxy.example.com/v1".into()),
+            Some("some-model".into()),
+        )
+        .expect("should construct");
+        assert_eq!(provider.default_model(), "some-model");
+    }
+}

--- a/crates/webclaw-server/src/routes/extract.rs
+++ b/crates/webclaw-server/src/routes/extract.rs
@@ -62,7 +62,7 @@ pub async fn extract(
     let chain = ProviderChain::default().await;
     if chain.is_empty() {
         return Err(ApiError::Llm(
-            "no LLM providers configured (set OLLAMA_HOST, OPENAI_API_KEY, or ANTHROPIC_API_KEY)"
+            "no LLM providers configured (set OLLAMA_HOST, OPENAI_API_KEY, or ANTHROPIC_API_KEY / ORCAROUTER_API_KEY)"
                 .to_string(),
         ));
     }

--- a/crates/webclaw-server/src/routes/summarize.rs
+++ b/crates/webclaw-server/src/routes/summarize.rs
@@ -39,7 +39,7 @@ pub async fn summarize_route(
     let chain = ProviderChain::default().await;
     if chain.is_empty() {
         return Err(ApiError::Llm(
-            "no LLM providers configured (set OLLAMA_HOST, OPENAI_API_KEY, or ANTHROPIC_API_KEY)"
+            "no LLM providers configured (set OLLAMA_HOST, OPENAI_API_KEY, or ANTHROPIC_API_KEY / ORCAROUTER_API_KEY)"
                 .to_string(),
         ));
     }

--- a/env.example
+++ b/env.example
@@ -18,6 +18,11 @@ OLLAMA_MODEL=qwen3:8b
 # ANTHROPIC_API_KEY — set your Anthropic key
 # ANTHROPIC_MODEL  — defaults to claude-sonnet-4-20250514
 
+# OrcaRouter (optional cloud fallback)
+# ORCAROUTER_API_KEY  — set your OrcaRouter key
+# ORCAROUTER_BASE_URL — defaults to https://api.orcarouter.ai/v1
+# ORCAROUTER_MODEL    — defaults to orcarouter/auto
+
 # --- Proxy ---
 
 # Single proxy


### PR DESCRIPTION
## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a named LLM provider, mirroring the existing Atlas Cloud wiring.

OrcaRouter is an OpenAI-compatible gateway that exposes a single endpoint for a wide range of models. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

- New `OrcaRouterProvider` in `crates/webclaw-llm/src/providers/orcarouter.rs`, delegating to the shared OpenAI-compatible transport, with `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` (default `https://api.orcarouter.ai/v1`) / `ORCAROUTER_MODEL` (default `orcarouter/auto`) overrides — the same shape as the Atlas Cloud provider.
- Added to the default provider chain (`chain.rs`) as an opt-in last fallback, so it only activates when `ORCAROUTER_API_KEY` is set and never preempts an already-configured provider.
- Registered `orcarouter` in the CLI `--llm-provider` selector, the "no LLM providers" hints (CLI + server), `env.example`, and the README config tables (EN + zh-CN). CHANGELOG entry added under Unreleased.

## How verified

- `cargo test -p webclaw-llm` — 62 passed, 0 failed.
- `cargo clippy -p webclaw-llm -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Live check against the OrcaRouter endpoint using the new provider path (`orcarouter/auto`): returned the expected completion.

Disclosure: I'm an engineer on the OrcaRouter team.
