### PR TITLE
fix(pdf): satisfy clippy::chunks_exact_to_as_chunks so CI is green again

### DIFF
--- a/crates/webclaw-pdf/src/lib.rs
+++ b/crates/webclaw-pdf/src/lib.rs
@@ -144,8 +144,11 @@ fn info_string(dict: &Dictionary, key: &[u8]) -> Option<String> {
     let text = if raw.len() >= 2 && raw[0] == 0xFE && raw[1] == 0xFF {
         // UTF-16BE: skip BOM, decode pairs
         let pairs: Vec<u16> = raw[2..]
-            .chunks_exact(2)
-            .map(|c| u16::from_be_bytes([c[0], c[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .copied()
+            .map(u16::from_be_bytes)
             .collect();
         String::from_utf16_lossy(&pairs)
     } else {


### PR DESCRIPTION
CI on `main` is currently red, and it blocks every open PR.

Rust **1.98** (2026-08-18) added `clippy::chunks_exact_to_as_chunks`, on by default. It fires on pre-existing code in `webclaw-pdf`, and CI runs `cargo clippy --all -- -D warnings` against `dtolnay/rust-toolchain@stable`.

Nothing pushed to `main` between 2026-08-16 and that release, so no run surfaced it until an external PR was re-checked. Because CI is now a required status check, this blocks PRs that have nothing to do with PDF decoding.

Reproduced on **unmodified main** after `rustup update stable`:

```
warning: using `chunks_exact` with a constant chunk size
  --> crates/webclaw-pdf/src/lib.rs:147:14
  help: consider using `as_chunks` instead: `as_chunks::<2>().0.iter()`
```

## The change

The UTF-16BE branch of the PDF string decoder now uses `as_chunks::<2>()`, which yields `[u8; 2]` directly. `u16::from_be_bytes` takes that array, so the `[c[0], c[1]]` reconstruction and its bounds checks go away.

Behaviour is identical: `as_chunks` splits on the same boundary as `chunks_exact` and discards the same trailing remainder, which for a UTF-16BE payload is an odd trailing byte already being dropped.

## Verified on rust 1.98

`clippy --all -D warnings`, `fmt --check --all`, `test --workspace`, `doc --no-deps --workspace`, and both wasm32 checks all pass.

## One note

This raises the effective floor to a toolchain with `as_chunks` stabilised. No crate declares `rust-version` and CI always uses latest stable, so nothing in-repo breaks. Worth knowing if an MSRV is ever pinned.