### PR TITLE
fix(release): reconcile v0.6.22 metadata and gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,17 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "--cfg reqwest_unstable"
 
+permissions:
+  contents: read
+
 jobs:
   release-metadata:
     name: Release metadata
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Validate release metadata contract
         run: |
@@ -26,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
@@ -35,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -47,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
@@ -62,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --no-deps --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,17 @@ env:
   RUSTFLAGS: "--cfg reqwest_unstable"
 
 jobs:
+  release-metadata:
+    name: Release metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Validate release metadata contract
+        run: |
+          version="$(awk '/^\[workspace.package\]$/{found=1; next} found && /^version = /{gsub(/"/, "", $3); print $3; exit}' Cargo.toml)"
+          ./scripts/release-preflight.sh "v${version}"
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     name: Release metadata
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - name: Validate release metadata contract
         run: |
           version="$(awk '/^\[workspace.package\]$/{found=1; next} found && /^version = /{gsub(/"/, "", $3); print $3; exit}' Cargo.toml)"
@@ -30,24 +30,24 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --workspace
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo fmt --check --all
       - run: cargo clippy --all -- -D warnings
 
@@ -55,13 +55,13 @@ jobs:
     name: WASM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       # webclaw-core must stay WASM-safe (zero network deps, no threads).
       # Check both with and without default features so the quickjs gate
       # can't regress.
@@ -72,9 +72,9 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo doc --no-deps --workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,15 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Fetch main for ancestry verification
         run: git fetch origin main:refs/remotes/origin/main
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: false
       - name: Validate release metadata
         run: ./scripts/release-preflight.sh "${GITHUB_REF_NAME}"
       - name: Check formatting
@@ -86,17 +83,13 @@ jobs:
             os: windows-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.target }}
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.target }}
 
       # Cross-compilation support for aarch64-linux
       # boring-sys2 builds BoringSSL from C source via cmake — needs cross-compiler + cmake
@@ -176,7 +169,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: ${{ matrix.target }}
           path: ${{ env.ASSET }}
@@ -189,7 +182,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           path: artifacts
 
@@ -229,18 +222,17 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
       - name: Pin launcher to this release and publish
         working-directory: packages/webclaw-mcp
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/webclaw-npmrc
         run: |
+          node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 18) process.exit(1)'
+          printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' > "$NPM_CONFIG_USERCONFIG"
           tag="${GITHUB_REF#refs/tags/}"   # e.g. v0.6.17 (core release)
           version="$(node -p "require('./package.json').version")"
           if [[ "v${version}" != "${tag}" ]]; then
@@ -263,17 +255,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: arm64
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -282,18 +274,34 @@ jobs:
       # The pushed tag, or the workflow_dispatch input for a manual re-publish.
       - name: Resolve tag
         id: tag
-        run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if [[ ! "$RELEASE_TAG" =~ $pattern ]]; then
+            echo "unsupported release tag" >&2
+            exit 1
+          fi
+          printf 'tag=%s\n' "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
 
       # Download pre-built binaries into TARGETARCH-named dirs (amd64/arm64) so
       # a single multi-platform build picks the matching binary per platform.
       - name: Download release binaries
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          tag="${{ steps.tag.outputs.tag }}"
+          curl --fail --show-error --silent --location \
+            "https://github.com/0xMassi/webclaw/releases/download/${RELEASE_TAG}/SHA256SUMS" \
+            --output SHA256SUMS
           declare -A arch=( [x86_64-unknown-linux-gnu]=amd64 [aarch64-unknown-linux-gnu]=arm64 )
           for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
-            dir="webclaw-${tag}-${target}"
-            curl -sSL "https://github.com/0xMassi/webclaw/releases/download/${tag}/${dir}.tar.gz" -o "${target}.tar.gz"
-            tar xzf "${target}.tar.gz"
+            dir="webclaw-${RELEASE_TAG}-${target}"
+            archive="${dir}.tar.gz"
+            curl --fail --show-error --silent --location \
+              "https://github.com/0xMassi/webclaw/releases/download/${RELEASE_TAG}/${archive}" \
+              --output "$archive"
+            grep -F "  ${archive}" SHA256SUMS | sha256sum --check --strict -
+            tar xzf "$archive"
             a="${arch[$target]}"
             mkdir -p "binaries-${a}"
             cp "${dir}/webclaw" "${dir}/webclaw-mcp" "${dir}/webclaw-server" "binaries-${a}/"
@@ -307,17 +315,18 @@ jobs:
       # failed before: "v0.6.9-arm64: not found"). Provenance/SBOM attestations
       # are disabled so each platform entry stays a plain image manifest.
       - name: Build and push
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          tag="${{ steps.tag.outputs.tag }}"
           # Only move :latest for stable tags. Prereleases (hyphenated, e.g.
-          # v1.2.3-rc1) still publish :${tag} for testing but must not clobber
+          # v1.2.3-rc1) still publish their version for testing but must not clobber
           # :latest.
           latest=""
-          case "$tag" in *-*) ;; *) latest="-t ghcr.io/0xmassi/webclaw:latest" ;; esac
+          case "$RELEASE_TAG" in *-*) ;; *) latest="-t ghcr.io/0xmassi/webclaw:latest" ;; esac
           docker buildx build -f Dockerfile.ci \
             --platform linux/amd64,linux/arm64 \
             --provenance=false --sbom=false \
-            -t "ghcr.io/0xmassi/webclaw:${tag}" \
+            -t "ghcr.io/0xmassi/webclaw:${RELEASE_TAG}" \
             $latest \
             --push .
 
@@ -335,13 +344,22 @@ jobs:
       - name: Compute all checksums and update formula
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          tag="${{ github.event.inputs.tag || github.ref_name }}"
-          base="https://github.com/0xMassi/webclaw/releases/download/${tag}"
+          pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          if [[ ! "$RELEASE_TAG" =~ $pattern ]]; then
+            echo "unsupported stable release tag" >&2
+            exit 1
+          fi
+          base="https://github.com/0xMassi/webclaw/releases/download/${RELEASE_TAG}"
+          curl --fail --show-error --silent --location "${base}/SHA256SUMS" --output SHA256SUMS
 
           # Download all tarballs (Linux + macOS) and compute SHAs
           for target in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu; do
-            curl -sSL "${base}/webclaw-${tag}-${target}.tar.gz" -o "${target}.tar.gz"
+            archive="webclaw-${RELEASE_TAG}-${target}.tar.gz"
+            curl --fail --show-error --silent --location "${base}/${archive}" --output "$archive"
+            grep -F "  ${archive}" SHA256SUMS | sha256sum --check --strict -
+            mv "$archive" "${target}.tar.gz"
           done
 
           SHA_MAC_ARM=$(sha256sum aarch64-apple-darwin.tar.gz | cut -d' ' -f1)
@@ -360,24 +378,24 @@ jobs:
             desc "The fastest web scraper for AI agents. 67% fewer tokens. Sub-ms extraction."
             homepage "https://webclaw.io"
             license "AGPL-3.0"
-            version "${tag#v}"
+            version "${RELEASE_TAG#v}"
 
             on_macos do
               if Hardware::CPU.arm?
-                url "${base}/webclaw-${tag}-aarch64-apple-darwin.tar.gz"
+                url "${base}/webclaw-${RELEASE_TAG}-aarch64-apple-darwin.tar.gz"
                 sha256 "${SHA_MAC_ARM}"
               else
-                url "${base}/webclaw-${tag}-x86_64-apple-darwin.tar.gz"
+                url "${base}/webclaw-${RELEASE_TAG}-x86_64-apple-darwin.tar.gz"
                 sha256 "${SHA_MAC_X86}"
               end
             end
 
             on_linux do
               if Hardware::CPU.arm?
-                url "${base}/webclaw-${tag}-aarch64-unknown-linux-gnu.tar.gz"
+                url "${base}/webclaw-${RELEASE_TAG}-aarch64-unknown-linux-gnu.tar.gz"
                 sha256 "${SHA_LINUX_ARM}"
               else
-                url "${base}/webclaw-${tag}-x86_64-unknown-linux-gnu.tar.gz"
+                url "${base}/webclaw-${RELEASE_TAG}-x86_64-unknown-linux-gnu.tar.gz"
                 sha256 "${SHA_LINUX_X86}"
               end
             end
@@ -404,5 +422,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/webclaw.rb
-          git diff --cached --quiet || git commit -m "Update webclaw to ${tag}"
+          git diff --cached --quiet || git commit -m "Update webclaw to ${RELEASE_TAG}"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Fetch main for ancestry verification
         run: git fetch origin main:refs/remotes/origin/main
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
       - name: Validate release metadata
         run: ./scripts/release-preflight.sh "${GITHUB_REF_NAME}"
       - name: Check formatting
@@ -84,6 +87,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -225,6 +230,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -235,15 +242,12 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           tag="${GITHUB_REF#refs/tags/}"   # e.g. v0.6.17 (core release)
-          # Pin which prebuilt binary this launcher downloads to the just-released tag.
-          sed -i -E "/const RELEASE_TAG =/ s|\"v[0-9.]+\"|\"${tag}\"|" webclaw-mcp.mjs
-          # The launcher is versioned INDEPENDENTLY of the core release (a
-          # launcher-only fix must be shippable without a core bump). Publish the
-          # next patch above whatever is currently on npm — no commit-back needed.
-          cur="$(npm view @webclaw/mcp version 2>/dev/null || echo 0.0.0)"
-          npm version "$cur" --no-git-tag-version --allow-same-version >/dev/null
-          npm version patch --no-git-tag-version >/dev/null
-          echo "publishing @webclaw/mcp@$(node -p "require('./package.json').version") pinned to ${tag}:"
+          version="$(node -p "require('./package.json').version")"
+          if [[ "v${version}" != "${tag}" ]]; then
+            echo "launcher version ${version} does not match release ${tag}" >&2
+            exit 1
+          fi
+          echo "publishing @webclaw/mcp@${version} pinned to ${tag}:"
           grep -n "RELEASE_TAG =" webclaw-mcp.mjs
           npm publish --access public
 
@@ -260,6 +264,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: docker/setup-qemu-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,37 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "--cfg reqwest_unstable"
 
 jobs:
+  preflight:
+    name: Release preflight
+    if: github.event_name == 'push'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Fetch main for ancestry verification
+        run: git fetch origin main:refs/remotes/origin/main
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Validate release metadata
+        run: ./scripts/release-preflight.sh "${GITHUB_REF_NAME}"
+      - name: Check formatting
+        run: cargo fmt --check --all
+      - name: Lint workspace
+        run: cargo clippy --all -- -D warnings
+      - name: Test workspace
+        run: cargo test --workspace
+
   build:
     # Binaries are only built when a tag is pushed. A manual dispatch reuses
     # the existing release's binaries, so it skips this job entirely.
     if: github.event_name == 'push'
+    needs: preflight
     permissions:
       contents: read
     name: Build ${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [0.6.22] - 2026-08-30
 
 ### Added
-- **OrcaRouter provider in the LLM chain (opt-in).** Set `ORCAROUTER_API_KEY` to add [OrcaRouter](https://www.orcarouter.ai) as a provider for extraction and summarization. It is appended after the existing configured providers, so it never preempts them. `ORCAROUTER_MODEL` and `ORCAROUTER_BASE_URL` override its model and endpoint.
-- **Cloud-only provider-chain construction.** Hosted services can use `ProviderChain::cloud_default()` when local Ollama discovery is deliberately not part of their deployment. The existing `ProviderChain::default()` behavior is unchanged for local CLI and self-hosted users.
+- **An additional optional hosted model provider.** Extraction and summarization can use another OpenAI-compatible routing service when it is configured, without changing provider priority for existing users.
+- **Cleaner managed-service model discovery.** Hosted deployments can now avoid probing local inference services that are not part of their configuration. Local CLI and self-hosted behavior is unchanged.
 
 ### Fixed
 - **A request the MCP server understands but cannot serve yet now says so accurately.** A request arriving before the connection is set up was refused with "method not found", even when the server implements that method and the request was simply missing information the newest protocol revision requires. It now answers "invalid params" and names what was missing, so a caller is pointed at their own request rather than at a feature they think is unimplemented. A method the server genuinely does not have still answers "method not found".
-- **XML entities survive document and sitemap parsing.** DOCX text, arXiv metadata, sitemap URLs, and XML attributes now preserve decoded entity references even when the XML reader reports them as separate events.
-- **Valid PDF headers near the end of the permitted prefix are accepted.** The preflight check now recognizes a `%PDF-` marker beginning anywhere in the first 1,024 bytes, including the final allowed offset.
+- **Encoded characters survive document and sitemap parsing.** DOCX text, metadata, sitemap URLs, and attributes no longer lose decoded entity references.
+- **Valid PDFs with a late header are accepted.** Files whose PDF marker appears near the end of the permitted prefix are no longer rejected at the boundary.
 
 ### Security
-- **Document parsers were upgraded and bounded.** The PDF, spreadsheet, and XML dependency chain was updated to patched releases. PDF parsing now rejects documents above 10,000 pages using a bounded count, while the existing 50 MiB input limit remains in force.
+- **Document parsing is patched and bounded.** PDF, spreadsheet, and XML dependencies were upgraded, and pathological PDFs are rejected before page processing can grow without a practical limit.
 
 ## [0.6.21] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-### Fixed
-- **A request the MCP server understands but cannot serve yet now says so accurately.** A request arriving before the connection is set up was refused with "method not found", even when the server implements that method and the request was simply missing information the newest protocol revision requires. It now answers "invalid params" and names what was missing, so a caller is pointed at their own request rather than at a feature they think is unimplemented. A method the server genuinely does not have still answers "method not found".
+## [0.6.22] - 2026-08-30
 
 ### Added
-- **OrcaRouter provider in the LLM chain (opt-in).** Set `ORCAROUTER_API_KEY` to add [OrcaRouter](https://www.orcarouter.ai) as a provider for the LLM features (extraction, summarization). It's added at the end of the chain — Ollama → OpenAI → Gemini → Anthropic → Atlas Cloud → OrcaRouter — so it only runs when you configure it and never preempts an already-configured provider. Override the model with `ORCAROUTER_MODEL` (default `orcarouter/auto`) and the endpoint with `ORCAROUTER_BASE_URL` (default `https://api.orcarouter.ai/v1`).
+- **OrcaRouter provider in the LLM chain (opt-in).** Set `ORCAROUTER_API_KEY` to add [OrcaRouter](https://www.orcarouter.ai) as a provider for extraction and summarization. It is appended after the existing configured providers, so it never preempts them. `ORCAROUTER_MODEL` and `ORCAROUTER_BASE_URL` override its model and endpoint.
+- **Cloud-only provider-chain construction.** Hosted services can use `ProviderChain::cloud_default()` when local Ollama discovery is deliberately not part of their deployment. The existing `ProviderChain::default()` behavior is unchanged for local CLI and self-hosted users.
+
+### Fixed
+- **A request the MCP server understands but cannot serve yet now says so accurately.** A request arriving before the connection is set up was refused with "method not found", even when the server implements that method and the request was simply missing information the newest protocol revision requires. It now answers "invalid params" and names what was missing, so a caller is pointed at their own request rather than at a feature they think is unimplemented. A method the server genuinely does not have still answers "method not found".
+- **XML entities survive document and sitemap parsing.** DOCX text, arXiv metadata, sitemap URLs, and XML attributes now preserve decoded entity references even when the XML reader reports them as separate events.
+- **Valid PDF headers near the end of the permitted prefix are accepted.** The preflight check now recognizes a `%PDF-` marker beginning anywhere in the first 1,024 bytes, including the final allowed offset.
+
+### Security
+- **Document parsers were upgraded and bounded.** The PDF, spreadsheet, and XML dependency chain was updated to patched releases. PDF parsing now rejects documents above 10,000 pages using a bounded count, while the existing 50 MiB input limit remains in force.
 
 ## [0.6.21] - 2026-08-16
 

--- a/packages/create-webclaw/server.json
+++ b/packages/create-webclaw/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.0xMassi/webclaw",
   "title": "webclaw",
   "description": "Turn any URL into clean markdown/JSON for AI agents. Self-hostable web content extraction.",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@webclaw/mcp",
-      "version": "0.6.21",
+      "version": "0.6.22",
       "transport": {
         "type": "stdio"
       }

--- a/packages/webclaw-mcp/package.json
+++ b/packages/webclaw-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webclaw/mcp",
-  "version": "0.6.16",
+  "version": "0.6.22",
   "description": "Zero-install launcher for the webclaw MCP server: web extraction and anti-bot access for AI agents. Runs `npx @webclaw/mcp`.",
   "type": "module",
   "bin": {

--- a/packages/webclaw-mcp/webclaw-mcp.mjs
+++ b/packages/webclaw-mcp/webclaw-mcp.mjs
@@ -38,7 +38,7 @@ import https from "node:https";
 const REPO = "0xMassi/webclaw";
 // Release the wrapper installs. Bump this (and the package version) on each
 // core release, or override at runtime with WEBCLAW_MCP_VERSION.
-const RELEASE_TAG = process.env.WEBCLAW_MCP_VERSION || "v0.6.15";
+const RELEASE_TAG = process.env.WEBCLAW_MCP_VERSION || "v0.6.22";
 
 const IS_WINDOWS = platform() === "win32";
 const BIN_NAME = IS_WINDOWS ? "webclaw-mcp.exe" : "webclaw-mcp";

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:-${GITHUB_REF_NAME:-}}"
+if [[ -z "$tag" || "$tag" != v* ]]; then
+  echo "release preflight requires a v-prefixed tag" >&2
+  exit 1
+fi
+
+version="${tag#v}"
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "release tag is not valid SemVer: $tag" >&2
+  exit 1
+fi
+
+workspace_version="$(awk '
+  /^\[workspace\.package\]$/ { in_workspace_package = 1; next }
+  /^\[/ { in_workspace_package = 0 }
+  in_workspace_package && /^version = / {
+    value = $3
+    gsub(/"/, "", value)
+    print value
+    exit
+  }
+' Cargo.toml)"
+
+if [[ "$workspace_version" != "$version" ]]; then
+  echo "tag $tag does not match workspace version $workspace_version" >&2
+  exit 1
+fi
+
+escaped_version="${version//./\\.}"
+if ! grep -Eq "^## \\[$escaped_version\\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md; then
+  echo "CHANGELOG.md has no dated [$version] release section" >&2
+  exit 1
+fi
+
+cargo metadata --format-version 1 --no-deps | python3 -c '
+import json
+import sys
+
+expected = sys.argv[1]
+metadata = json.load(sys.stdin)
+wrong = sorted(
+    "{}={}".format(package["name"], package["version"])
+    for package in metadata["packages"]
+    if package["version"] != expected
+)
+if wrong:
+    raise SystemExit(
+        "workspace packages do not match release version "
+        + expected
+        + ": "
+        + ", ".join(wrong)
+    )
+' "$version"
+
+# Stable releases are immediately published to npm and the MCP registry, so
+# the checked-in registry manifest must describe the same version. Prerelease
+# tags intentionally skip those publication jobs.
+if [[ "$version" != *-* ]]; then
+  python3 -c '
+import json
+import sys
+
+expected = sys.argv[1]
+with open("packages/create-webclaw/server.json", encoding="utf-8") as source:
+    manifest = json.load(source)
+
+observed = {
+    manifest.get("version"),
+    *(package.get("version") for package in manifest.get("packages", [])),
+}
+if observed != {expected}:
+    raise SystemExit(
+        "packages/create-webclaw/server.json versions do not all match " + expected
+    )
+' "$version"
+fi
+
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+  tag_commit="$(git rev-parse "${tag}^{commit}")"
+  if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
+    echo "release tag $tag does not point to a commit on main" >&2
+    exit 1
+  fi
+fi
+
+echo "release metadata is consistent for $tag"

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -8,7 +8,8 @@ if [[ -z "$tag" || "$tag" != v* ]]; then
 fi
 
 version="${tag#v}"
-if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+semver_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
+if [[ ! "$version" =~ $semver_pattern ]]; then
   echo "release tag is not valid SemVer: $tag" >&2
   exit 1
 fi

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -2,15 +2,18 @@
 set -euo pipefail
 
 tag="${1:-${GITHUB_REF_NAME:-}}"
-if [[ -z "$tag" || "$tag" != v* ]]; then
+if [[ ! "$tag" =~ ^v ]]; then
   echo "release preflight requires a v-prefixed tag" >&2
   exit 1
 fi
 
 version="${tag#v}"
-semver_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
-if [[ ! "$version" =~ $semver_pattern ]]; then
-  echo "release tag is not valid SemVer: $tag" >&2
+# Docker tags cannot contain SemVer's optional `+build.metadata` suffix. Keep
+# the shared release version portable across GitHub, Cargo, npm, and GHCR by
+# supporting strict numeric SemVer with an optional prerelease suffix only.
+release_version_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
+if [[ ! "$version" =~ $release_version_pattern ]]; then
+  echo "unsupported release tag: $tag (expected vMAJOR.MINOR.PATCH with optional prerelease identifiers)" >&2
   exit 1
 fi
 

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -67,16 +67,25 @@ import sys
 expected = sys.argv[1]
 with open("packages/create-webclaw/server.json", encoding="utf-8") as source:
     manifest = json.load(source)
+with open("packages/webclaw-mcp/package.json", encoding="utf-8") as source:
+    launcher = json.load(source)
 
 observed = {
     manifest.get("version"),
     *(package.get("version") for package in manifest.get("packages", [])),
+    launcher.get("version"),
 }
 if observed != {expected}:
     raise SystemExit(
-        "packages/create-webclaw/server.json versions do not all match " + expected
+        "release, registry, and launcher versions do not all match " + expected
     )
 ' "$version"
+
+  if ! grep -Fq "const RELEASE_TAG = process.env.WEBCLAW_MCP_VERSION || \"$tag\";" \
+    packages/webclaw-mcp/webclaw-mcp.mjs; then
+    echo "MCP launcher is not pinned to $tag" >&2
+    exit 1
+  fi
 fi
 
 if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then


### PR DESCRIPTION
## Summary

Corrects the release metadata that was omitted when `v0.6.22` was tagged and prevents a tag from publishing again unless the release contract is complete.

- adds the dated `0.6.22` changelog section
- aligns the MCP registry manifest with `0.6.22`
- adds a reusable release preflight for tag/version, changelog, workspace-package, registry-manifest, and main-ancestry checks
- runs that contract in ordinary CI
- makes tag publication wait for metadata validation, formatting, strict Clippy, and the complete workspace tests

This PR does **not** move or recreate `v0.6.22`, publish a new version, or change any release binary. The existing release remains immutable.

## GitHub reconciliation

- PR #105 remains open, conflicting, and out of this patch release; its latest review still requires the extraction-failure escalation ordering fix.
- Issue #104 remains open pending #105.
- Issue #117 remains open while the conformance-suite interpretation is discussed; its confirmed error-code defect was fixed by #119 and is documented here.

## Validation

- `./scripts/release-preflight.sh v0.6.22`
- negative preflight with `v0.6.21` fails as expected
- `cargo fmt --all --check`
- `cargo test --workspace --lib --bins -- --test-threads=1`
- `cargo build --release`
- `cargo clippy --all -- -D warnings`
- `cargo audit` (zero vulnerabilities; two upstream unmaintained warnings)
- local CLI positive scrape and metadata-address rejection
- local MCP initialize, 14-tool catalog, positive scrape, and metadata-address rejection
- local self-hosted REST positive scrape, private-address rejection, mixed unsafe batch rejection, and public-bind refusal
- published macOS arm64 archive checksum, CLI, MCP, and REST verification
- `@webclaw/mcp@0.6.22` install plus MCP positive/negative smoke
- published `ghcr.io/0xmassi/webclaw:v0.6.22` CLI, public-bind guard, authenticated REST, and private-address smoke on the API VPS
- Homebrew `0.6.22` formula URL and arm64 checksum matched against `SHA256SUMS`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML entity preservation across document formats.
  * Improved PDF detection when the file marker appears within the first 1,024 bytes.

* **Security**
  * Updated document parsers with bounded processing to reject pathological files safely.

* **Chores**
  * Updated the MCP server, launcher, and package version to 0.6.22.
  * Added automated release validation, formatting checks, linting, and tests.
  * Improved release consistency checks across published packages and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->