### PR TITLE
Expose optional response payload observations

### DIFF
--- a/crates/webclaw-fetch/src/client.rs
+++ b/crates/webclaw-fetch/src/client.rs
@@ -146,7 +146,11 @@ impl Response {
     /// negotiated), so a tiny compressed payload that inflates to
     /// gigabytes is aborted as soon as the accumulated size crosses the
     /// cap — it never gets fully buffered in memory.
-    async fn from_wreq(resp: wreq::Response) -> Result<Self, FetchError> {
+    async fn from_wreq(
+        resp: wreq::Response,
+        mut attempt: crate::transfer::Attempt,
+    ) -> Result<Self, FetchError> {
+        attempt.transfer.status = Some(resp.status().as_u16());
         if let Some(len) = resp.content_length()
             && len > MAX_BODY_BYTES
         {
@@ -166,10 +170,15 @@ impl Response {
         let mut stream = resp.bytes_stream();
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(|e| FetchError::BodyDecode(e.to_string()))?;
+            attempt.transfer.decoded_bytes = attempt
+                .transfer
+                .decoded_bytes
+                .saturating_add(chunk.len() as u64);
             check_body_ceiling(buf.len(), chunk.len())?;
             buf.extend_from_slice(&chunk);
         }
 
+        attempt.transfer.complete = true;
         Ok(Self {
             status,
             url,
@@ -225,16 +234,27 @@ impl Response {
 }
 
 /// Internal representation of the client pool strategy.
+struct ObservedClient {
+    client: wreq::Client,
+    proxy: Option<String>,
+}
+impl std::ops::Deref for ObservedClient {
+    type Target = wreq::Client;
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
 enum ClientPool {
     /// Pre-built clients with a fixed proxy (or no proxy).
     /// Fingerprint rotation still works via the pool when `random` is true.
     Static {
-        clients: Vec<wreq::Client>,
+        clients: Vec<ObservedClient>,
         random: bool,
     },
     /// Pre-built pool of clients, each with a different proxy + fingerprint.
     /// Requests pick a client deterministically by host for HTTP/2 connection reuse.
-    Rotating { clients: Vec<wreq::Client> },
+    Rotating { clients: Vec<ObservedClient> },
 }
 
 /// HTTP client with browser TLS + HTTP/2 fingerprinting via wreq.
@@ -306,6 +326,10 @@ impl FetchClient {
                         config.follow_redirects,
                         config.max_redirects,
                     )
+                    .map(|client| ObservedClient {
+                        client,
+                        proxy: config.proxy.as_deref().and_then(crate::transfer::authority),
+                    })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
@@ -332,6 +356,10 @@ impl FetchClient {
                         config.follow_redirects,
                         config.max_redirects,
                     )
+                    .map(|client| ObservedClient {
+                        client,
+                        proxy: crate::transfer::authority(proxy),
+                    })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
@@ -488,8 +516,9 @@ impl FetchClient {
         for (k, v) in extra {
             req = req.header(*k, *v);
         }
+        let attempt = crate::transfer::Attempt::new(url, client.proxy.as_deref());
         let resp = req.send().await?;
-        let response = Response::from_wreq(resp).await?;
+        let response = Response::from_wreq(resp, attempt).await?;
         response_to_result(response, start)
     }
 
@@ -569,8 +598,9 @@ impl FetchClient {
         let parsed_url = crate::url_security::validate_public_http_url(url).await?;
         let url = parsed_url.as_str();
         let client = self.pick_client(url);
+        let attempt = crate::transfer::Attempt::new(url, client.proxy.as_deref());
         let resp = client.get(url).send().await?;
-        let response = Response::from_wreq(resp).await?;
+        let response = Response::from_wreq(resp, attempt).await?;
         Ok((response.status(), response.into_body()))
     }
 
@@ -607,8 +637,9 @@ impl FetchClient {
 
         let start = Instant::now();
         let client = self.pick_client(url);
+        let attempt = crate::transfer::Attempt::new(url, client.proxy.as_deref());
         let resp = client.get(url).send().await?;
-        let mut response = Response::from_wreq(resp).await?;
+        let mut response = Response::from_wreq(resp, attempt).await?;
 
         // Cookie warmup: if we get a challenge page, visit the homepage first
         // to collect Akamai cookies (_abck, bm_sz, etc.), then retry.
@@ -617,8 +648,9 @@ impl FetchClient {
         {
             debug!("challenge detected, warming cookies via {homepage}");
             let _ = self.fetch(&homepage).await;
+            let attempt = crate::transfer::Attempt::new(url, client.proxy.as_deref());
             let resp = client.get(url).send().await?;
-            response = Response::from_wreq(resp).await?;
+            response = Response::from_wreq(resp, attempt).await?;
             debug!("retried after cookie warmup: status={}", response.status());
         }
 
@@ -699,7 +731,7 @@ impl FetchClient {
             let client = Arc::clone(self);
             let url = url.to_string();
 
-            handles.push(tokio::spawn(async move {
+            handles.push(crate::transfer::spawn(async move {
                 // Don't panic if the semaphore has been closed under us
                 // (adversarial runtime state or shutdown race). Surface a
                 // typed error instead so the caller sees one failed URL in
@@ -745,7 +777,7 @@ impl FetchClient {
             let url = url.to_string();
             let opts = options.clone();
 
-            handles.push(tokio::spawn(async move {
+            handles.push(crate::transfer::spawn(async move {
                 let result = match permit.acquire().await {
                     Ok(_permit) => client.fetch_and_extract_with_options(&url, &opts).await,
                     Err(_) => Err(FetchError::Build("semaphore closed before acquire".into())),
@@ -811,7 +843,7 @@ impl FetchClient {
     }
 
     /// Pick a client from the pool for a given URL.
-    fn pick_client(&self, url: &str) -> &wreq::Client {
+    fn pick_client(&self, url: &str) -> &ObservedClient {
         match &self.pool {
             ClientPool::Static { clients, random } => {
                 if *random {
@@ -895,7 +927,7 @@ fn extract_host(url: &str) -> String {
 
 /// Pick a client deterministically based on a host string.
 /// Same host always gets the same client, enabling HTTP/2 connection reuse.
-fn pick_for_host<'a>(clients: &'a [wreq::Client], host: &str) -> &'a wreq::Client {
+fn pick_for_host<'a>(clients: &'a [ObservedClient], host: &str) -> &'a ObservedClient {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     host.hash(&mut hasher);
     let idx = (hasher.finish() as usize) % clients.len();
@@ -903,7 +935,7 @@ fn pick_for_host<'a>(clients: &'a [wreq::Client], host: &str) -> &'a wreq::Clien
 }
 
 /// Pick a random client from the pool for per-request rotation.
-fn pick_random(clients: &[wreq::Client]) -> &wreq::Client {
+fn pick_random(clients: &[ObservedClient]) -> &ObservedClient {
     use rand::Rng;
     let idx = rand::thread_rng().gen_range(0..clients.len());
     &clients[idx]
@@ -1035,6 +1067,48 @@ async fn collect_ordered<T>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    #[ignore = "requires local TCP sockets"]
+    async fn transfer_observer_counts_partial_body_when_stream_fails() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0; 4096];
+            socket.read(&mut request).await.unwrap();
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n")
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            // Missing terminator: the body read must fail after these 3 bytes.
+        });
+        let rows = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = rows.clone();
+        let observer: crate::transfer::Observer = Arc::new(move |t| sink.lock().unwrap().push(t));
+        crate::transfer::observe(Some(observer), async {
+            let url = format!("http://{addr}/");
+            let attempt = crate::transfer::Attempt::new(&url, Some("proxy.example:123"));
+            let response = wreq::Client::builder()
+                .no_proxy()
+                .build()
+                .unwrap()
+                .get(&url)
+                .send()
+                .await
+                .unwrap();
+            assert!(Response::from_wreq(response, attempt).await.is_err());
+        })
+        .await;
+        server.await.unwrap();
+        let rows = rows.lock().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].decoded_bytes, 3);
+        assert_eq!(rows[0].status, Some(200));
+        assert!(!rows[0].complete);
+    }
 
     /// Build a `Response` around a raw body so the decode path can be tested
     /// without a network round trip.

--- a/crates/webclaw-fetch/src/crawler.rs
+++ b/crates/webclaw-fetch/src/crawler.rs
@@ -362,7 +362,7 @@ impl Crawler {
                 let depth = *depth;
                 let delay = self.config.delay;
 
-                handles.push(tokio::spawn(async move {
+                handles.push(crate::transfer::spawn(async move {
                     // Acquire permit -- blocks if concurrency limit reached.
                     // Surface semaphore-closed as a failed PageResult rather
                     // than panicking the spawned task and silently dropping

--- a/crates/webclaw-fetch/src/lib.rs
+++ b/crates/webclaw-fetch/src/lib.rs
@@ -18,6 +18,7 @@ pub mod reddit;
 pub mod search;
 pub mod sitemap;
 pub mod tls;
+pub mod transfer;
 pub mod url_security;
 mod xml;
 

--- a/crates/webclaw-fetch/src/transfer.rs
+++ b/crates/webclaw-fetch/src/transfer.rs
@@ -1,0 +1,116 @@
+//! Optional response-payload observation. Counts decoded bytes actually read,
+//! including partial bodies and retries. This is NOT wire or invoice metering:
+//! redirect bodies consumed internally, request bytes and protocol overhead are
+//! not exposed by the HTTP transport. Callbacks must be quick and non-panicking.
+use std::{future::Future, sync::Arc};
+
+#[derive(Debug, Clone)]
+pub struct Transfer {
+    pub host: String,
+    /// Authority only; credentials and URL paths are never included.
+    pub proxy: Option<String>,
+    pub decoded_bytes: u64,
+    pub status: Option<u16>,
+    pub complete: bool,
+}
+
+pub type Observer = Arc<dyn Fn(Transfer) + Send + Sync>;
+
+tokio::task_local! { static OBSERVER: Option<Observer>; }
+
+pub async fn observe<F: Future>(observer: Option<Observer>, future: F) -> F::Output {
+    OBSERVER.scope(observer, future).await
+}
+
+/// Spawn work with the current observer, so background batches/crawls retain
+/// attribution after the initiating request has completed.
+pub fn spawn<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    let observer = OBSERVER.try_with(Clone::clone).ok().flatten();
+    tokio::spawn(observe(observer, future))
+}
+
+pub fn record(transfer: Transfer) {
+    let _ = OBSERVER.try_with(|observer| {
+        if let Some(observer) = observer {
+            observer(transfer);
+        }
+    });
+}
+
+pub(crate) fn authority(value: &str) -> Option<String> {
+    let url = url::Url::parse(value).ok()?;
+    Some(match url.port() {
+        Some(port) => format!("{}:{port}", url.host()?),
+        None => url.host()?.to_string(),
+    })
+}
+
+pub(crate) struct Attempt {
+    observer: Option<Observer>,
+    pub transfer: Transfer,
+}
+
+impl Attempt {
+    pub fn new(url: &str, proxy: Option<&str>) -> Self {
+        Self {
+            observer: OBSERVER.try_with(Clone::clone).ok().flatten(),
+            transfer: Transfer {
+                host: authority(url).unwrap_or_default(),
+                proxy: proxy.map(str::to_owned),
+                decoded_bytes: 0,
+                status: None,
+                complete: false,
+            },
+        }
+    }
+}
+
+impl Drop for Attempt {
+    fn drop(&mut self) {
+        if let Some(observer) = self.observer.take() {
+            observer(self.transfer.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[tokio::test]
+    async fn cancellation_and_spawn_keep_separate_request_attribution() {
+        let a = Arc::new(Mutex::new(Vec::new()));
+        let b = Arc::new(Mutex::new(Vec::new()));
+        let run = |sink: Arc<Mutex<Vec<Transfer>>>, bytes| async move {
+            let observer: Observer = Arc::new(move |t| sink.lock().unwrap().push(t));
+            observe(Some(observer), async move {
+                spawn(async move {
+                    let mut attempt = Attempt::new(
+                        "https://user:secret@example.com/private?key=secret",
+                        Some("proxy.example:123"),
+                    );
+                    attempt.transfer.decoded_bytes = bytes;
+                    tokio::task::yield_now().await;
+                    // Partial/error return drops the attempt and retains bytes.
+                })
+                .await
+                .unwrap();
+            })
+            .await;
+        };
+        tokio::join!(run(a.clone(), 123), run(b.clone(), 456));
+        assert_eq!(a.lock().unwrap()[0].decoded_bytes, 123);
+        assert_eq!(b.lock().unwrap()[0].decoded_bytes, 456);
+        assert_eq!(a.lock().unwrap()[0].host, "example.com");
+        assert!(!a.lock().unwrap()[0].complete);
+        assert_eq!(
+            authority("http://user:password@proxy.example:123"),
+            Some("proxy.example:123".into())
+        );
+    }
+}


### PR DESCRIPTION
Response payload observations are now available to applications through an optional task-scoped observer. The observer records bytes actually read, preserves partial reads on failures and cancellation, and follows spawned crawl work. Gateway metadata contains only its authority.

The measurement is decoded response payload, not wire transfer or a billing metric. It excludes request traffic, protocol overhead, and redirect bodies consumed internally by the HTTP client.

Validation: 786 core workspace tests passed, plus the interrupted-stream network test. Release builds, CLI/MCP/self-hosted REST public and unsafe-address checks, and Docker CLI/REST checks passed. Independent review approved the change.

Draft pending the hosted staging integration gate. Candidate: `228fea711c960f03aa420913eba4b5bd407afc59`; integration tag: `rc/v0.6.22-transfer.1`. No final release or main promotion yet.
