### PR TITLE
docs: refresh NodeMaven sponsor links and offers

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,17 +471,25 @@ Please remove secrets, cookies, private tokens, and customer data from logs befo
 <table>
   <tr>
     <td width="340" align="center">
-      <a href="https://go.nodemaven.com/webclawgh">
+      <a href="https://go.nodemaven.com/webclawrmaugust">
         <img src="./assets/sponsors/nodemaven-banner.png" alt="NodeMaven" width="300" />
       </a>
     </td>
     <td>
-      <strong>NodeMaven</strong> is the most reliable proxy provider with the highest-quality IPs on the market.
-      Best solution for automation, web scraping, SEO research, and social media management: 99.9% uptime,
-      sticky sessions up to 7 days, IP filtering (all proxies under a 97% fraud score), no KYC, and cashback up
-      to 10% on traffic. Use <code>WEBCLAW35</code> for 35% off Mobile and Residential proxies, or
-      <code>WEBCLAW40</code> for 40% off ISP (Static) proxies at
-      <a href="https://go.nodemaven.com/webclawgh">NodeMaven</a>.
+      <p><a href="https://go.nodemaven.com/webclawrmaugust"><strong>NodeMaven</strong></a>: The most efficient proxy provider for Web Scraping and Automation with the Highest Quality IP on the market.</p>
+      <p><a href="https://go.nodemaven.com/webclawrmaugust"><strong>Why NodeMaven?</strong></a></p>
+      <ul>
+        <li>ZIP targeting</li>
+        <li>99.9% uptime</li>
+        <li>IP filtering: all proxies have fraud score &lt;97%</li>
+        <li>No KYC required</li>
+        <li>Unique free tools: Proxy Bandwidth Checker, Meta Tag Checker, IP Lookup and others!</li>
+      </ul>
+      <p><strong>Special codes for Webclaw users:</strong></p>
+      <ul>
+        <li><code>WEBCLAW35</code> - 35% off to Mobile and Residential Proxies</li>
+        <li><code>WEBCLAW40</code> - 40% off to ISP (Static) Proxies</li>
+      </ul>
     </td>
   </tr>
   <tr>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -429,15 +429,25 @@ URL:
 <table>
   <tr>
     <td width="340" align="center">
-      <a href="https://go.nodemaven.com/webclawgh">
+      <a href="https://go.nodemaven.com/webclawrmaugust">
         <img src="./assets/sponsors/nodemaven-banner.png" alt="NodeMaven" width="300" />
       </a>
     </td>
     <td>
-      <strong>NodeMaven</strong> 提供市场上最可靠、IP 质量最高的代理服务。适用于自动化、网页抓取、SEO 研究
-      与社媒管理：99.9% 在线率、最长 7 天的粘性会话、IP 过滤（所有代理欺诈评分低于 97%）、无需 KYC，
-      并提供最高 10% 的流量返现。在 <a href="https://go.nodemaven.com/webclawgh">NodeMaven</a> 使用
-      <code>WEBCLAW35</code> 享移动与住宅代理 35% 折扣，或用 <code>WEBCLAW40</code> 享 ISP（静态）代理 40% 折扣。
+      <p><a href="https://go.nodemaven.com/webclawrmaugust"><strong>NodeMaven</strong></a>：最高效的网页抓取与自动化代理服务商，提供市场上最高质量的 IP。</p>
+      <p><a href="https://go.nodemaven.com/webclawrmaugust"><strong>为什么选择 NodeMaven？</strong></a></p>
+      <ul>
+        <li>邮政编码定位</li>
+        <li>99.9% 在线率</li>
+        <li>IP 过滤：所有代理的欺诈评分均 &lt;97%</li>
+        <li>无需 KYC 验证</li>
+        <li>独家免费工具：Proxy Bandwidth Checker、Meta Tag Checker、IP Lookup 等！</li>
+      </ul>
+      <p><strong>Webclaw 用户专属优惠码：</strong></p>
+      <ul>
+        <li><code>WEBCLAW35</code> - 移动与住宅代理享 35% 折扣</li>
+        <li><code>WEBCLAW40</code> - ISP（静态）代理享 40% 折扣</li>
+      </ul>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
Update the English and Simplified Chinese README sponsor sections with NodeMaven’s supplied copy, five benefits, and Webclaw discount offers. All three links in each placement now use the README tracking URL, including the linked brand name and “Why NodeMaven?” heading.

Validation: GitHub’s Markdown renderer preserves the lists, discount codes, and literal `<97%`; all README tracking links match the supplied URL. Both supplied tracking URLs resolved successfully through the Webclaw CLI. The diff is limited to the two READMEs, with no runtime or release changes; Rust, CLI/MCP/REST, and Docker release checks were not run for this documentation-only update.
